### PR TITLE
fix: improve E2E test infrastructure and move to manual-only workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,54 +67,6 @@ jobs:
             coverage/
           retention-days: 7
 
-  e2e-tests:
-    name: E2E Tests (Optional)
-    runs-on: ubuntu-latest
-    needs: integration-tests
-    # Only run E2E tests on main branch or when manually triggered
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Setup GitHub CLI
-        run: |
-          type -p gh > /dev/null || (
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt update
-            sudo apt install gh
-          )
-
-      - name: Run E2E tests
-        env:
-          GITHUB_TEST_TOKEN: ${{ secrets.GITHUB_TEST_TOKEN }}
-          GITHUB_TEST_OWNER: ${{ vars.GITHUB_TEST_OWNER || 'gh-please-e2e' }}
-          GITHUB_TEST_REPO: ${{ vars.GITHUB_TEST_REPO || 'test-repo' }}
-        run: |
-          if [ -z "$GITHUB_TEST_TOKEN" ]; then
-            echo "⊘ Skipping E2E tests (GITHUB_TEST_TOKEN not configured)"
-            echo "To enable E2E tests, add GITHUB_TEST_TOKEN to repository secrets"
-            exit 0
-          fi
-
-          echo "🚀 Running E2E tests..."
-          bun run test:e2e
-
-      - name: Upload E2E test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-test-results
-          path: |
-            test/e2e/**/*.log
-          retention-days: 7
-
   build:
     runs-on: ubuntu-latest
     steps:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,193 @@
+# E2E Tests for gh-please
+
+End-to-end tests that verify commands against the real GitHub API.
+
+## Setup
+
+### 1. Create GitHub Personal Access Token
+
+Create a token with the following scopes:
+- `repo` (full repository access) - **Required** for GraphQL operations
+
+Create token at: https://github.com/settings/tokens/new
+
+### 2. Create Test Repository
+
+Create a test repository on GitHub:
+- Repository name: `gh-please-e2e` (or your custom name)
+- Enable GitHub Issues
+- **Important**: Sub-issues feature requires GitHub Enterprise or beta access
+
+### 3. Set Environment Variables
+
+```bash
+# Required
+export GITHUB_TEST_TOKEN=ghp_...    # Your GitHub PAT with 'repo' scope
+
+# Optional (defaults shown)
+export GITHUB_TEST_OWNER=pleaseai   # Repository owner
+export GITHUB_TEST_REPO=gh-please-e2e  # Repository name
+export E2E_SKIP_CLEANUP=false       # Set to 'true' to keep test artifacts
+```
+
+### 4. Run E2E Tests
+
+```bash
+# Run all E2E tests
+bun test test/e2e/
+
+# Run specific test suite
+bun test test/e2e/sub-issue.e2e.test.ts
+bun test test/e2e/dependency.e2e.test.ts
+```
+
+## Test Behavior
+
+### What Gets Created
+- Test issues with `[E2E TEST]` prefix
+- Sub-issue relationships
+- Issue dependencies (blocked_by)
+
+### Automatic Cleanup
+- By default, all test issues are closed after tests complete
+- Set `E2E_SKIP_CLEANUP=true` to preserve artifacts for debugging
+
+### Skipping Tests
+- If `GITHUB_TEST_TOKEN` is not set, E2E tests are automatically skipped
+- This allows running unit tests without E2E setup
+
+## Troubleshooting
+
+### HTTP 403 Errors
+```
+gh: Resource not accessible by personal access token (HTTP 403)
+```
+
+**Causes:**
+1. Token missing `repo` scope
+2. Repository doesn't have sub-issues feature enabled
+3. Token doesn't have access to the test repository
+
+**Solutions:**
+1. Recreate token with `repo` scope
+2. Use GitHub Enterprise repository or request beta access
+3. Verify token has access to `{owner}/{repo}`
+
+### Issue Creation Returns `undefined`
+```
+✓ Created blocked issue #undefined
+```
+
+**Fixed in v0.11.0**: Labels are now sent correctly as array format (`labels[]=...`)
+
+### Tests Skip Automatically
+```
+⊘ Skipping E2E tests (GITHUB_TEST_TOKEN not set)
+```
+
+This is normal behavior when `GITHUB_TEST_TOKEN` is not set. Set the token to run E2E tests.
+
+## CI/CD Integration
+
+### GitHub Actions Manual Workflow
+
+E2E tests are **not** run automatically in CI to avoid API rate limits and test repository pollution. Instead, use the manual workflow:
+
+1. Go to **Actions** → **Manual E2E Tests**
+2. Click **Run workflow**
+3. Configure parameters (optional):
+   - `test_owner`: Repository owner (default: `pleaseai`)
+   - `test_repo`: Repository name (default: `gh-please-e2e`)
+   - `skip_cleanup`: Keep test artifacts for debugging (default: `false`)
+4. Click **Run workflow**
+
+**Required Setup:**
+- Add `GH_PLEASE_TEST_TOKEN` secret to repository settings
+  - Settings → Secrets and variables → Actions → New repository secret
+  - Token must have `repo` scope
+
+**Why manual only?**
+- ✅ Saves GitHub API rate limits
+- ✅ Avoids test repository pollution
+- ✅ Run only when needed (before releases, after major changes)
+- ✅ Customizable parameters for debugging
+
+## Test Coverage
+
+### Sub-issue Management (sub-issue.e2e.test.ts)
+- ✅ Create new sub-issue
+- ✅ Add existing issue as sub-issue
+- ✅ List sub-issues
+- ✅ Remove sub-issue link
+- ✅ Error handling (invalid parent, self-linking)
+
+### Dependency Management (dependency.e2e.test.ts)
+- ✅ Add blocked-by dependency
+- ✅ Add multiple dependencies
+- ✅ List dependencies
+- ✅ Remove dependency
+- ✅ Handle issues with no dependencies
+- ✅ Error handling (invalid issue, invalid blocker)
+
+## Development
+
+### Adding New E2E Tests
+
+1. Create test file in `test/e2e/`
+2. Use `setupE2ESuite()` for setup/teardown
+3. Use `E2ETestHelper` for common operations:
+   - `createTestIssue()` - Create test issues
+   - `getIssue()` - Fetch issue details
+   - `hasComment()` - Check for comments
+   - `waitFor()` - Wait for conditions
+
+4. Use `runE2ECommand()` to execute CLI commands
+
+Example:
+```typescript
+import { runE2ECommand, setupE2ESuite } from './setup'
+
+describe('My E2E Tests', () => {
+  let helper: E2ETestHelper | null = null
+
+  beforeAll(async () => {
+    helper = setupE2ESuite()
+  })
+
+  test('should do something', async () => {
+    if (!helper) {
+      console.log('⊘ Skipping (E2E not enabled)')
+      return
+    }
+
+    const config = helper.getConfig()
+    const issueNumber = await helper.createTestIssue('Test Issue')
+
+    const result = await runE2ECommand([
+      'issue',
+      'some-command',
+      String(issueNumber)
+    ], config)
+
+    expect(result.exitCode).toBe(0)
+  })
+})
+```
+
+## Architecture
+
+### Files
+- `setup.ts` - E2E infrastructure (config, helpers, cleanup)
+- `*.e2e.test.ts` - Test suites
+- `README.md` - This file
+
+### Key Classes
+- `E2EConfig` - Environment configuration
+- `E2ETestHelper` - Test utilities
+- `TestArtifacts` - Tracks created resources for cleanup
+
+### Design Principles
+- Tests are independent and can run in any order
+- Automatic cleanup prevents test pollution
+- Graceful skipping when not configured
+- Clear error messages for common issues

--- a/test/e2e/dependency.e2e.test.ts
+++ b/test/e2e/dependency.e2e.test.ts
@@ -4,10 +4,16 @@
  *
  * NOTE: These tests only run when GITHUB_TEST_TOKEN is set
  * Set the following environment variables to run these tests:
- * - GITHUB_TEST_TOKEN: GitHub personal access token
- * - GITHUB_TEST_OWNER: Test repository owner (default: gh-please-e2e)
- * - GITHUB_TEST_REPO: Test repository name (default: test-repo)
+ * - GITHUB_TEST_TOKEN: GitHub personal access token with 'repo' scope
+ * - GITHUB_TEST_OWNER: Test repository owner (default: pleaseai)
+ * - GITHUB_TEST_REPO: Test repository name (default: gh-please-e2e)
  * - E2E_SKIP_CLEANUP: Set to 'true' to skip cleanup (useful for debugging)
+ *
+ * REQUIREMENTS:
+ * - Token must have 'repo' scope (full repository access)
+ * - Test repository must have GitHub Issues enabled
+ * - Repository must have sub-issues feature enabled (GitHub Enterprise or beta)
+ * - If you get HTTP 403 errors, check token permissions and repository settings
  */
 
 import type { E2ETestHelper } from './setup'
@@ -116,7 +122,7 @@ describe('Dependency Management - E2E', () => {
     ], config)
 
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Dependencies blocking')
+    expect(result.stdout).toMatch(/blocked by \d+ issue/i)
     expect(result.stdout).toContain(`#${blockingIssue1Number}`)
     expect(result.stdout).toContain(`#${blockingIssue2Number}`)
 

--- a/test/e2e/sub-issue.e2e.test.ts
+++ b/test/e2e/sub-issue.e2e.test.ts
@@ -4,10 +4,16 @@
  *
  * NOTE: These tests only run when GITHUB_TEST_TOKEN is set
  * Set the following environment variables to run these tests:
- * - GITHUB_TEST_TOKEN: GitHub personal access token
- * - GITHUB_TEST_OWNER: Test repository owner (default: gh-please-e2e)
- * - GITHUB_TEST_REPO: Test repository name (default: test-repo)
+ * - GITHUB_TEST_TOKEN: GitHub personal access token with 'repo' scope
+ * - GITHUB_TEST_OWNER: Test repository owner (default: pleaseai)
+ * - GITHUB_TEST_REPO: Test repository name (default: gh-please-e2e)
  * - E2E_SKIP_CLEANUP: Set to 'true' to skip cleanup (useful for debugging)
+ *
+ * REQUIREMENTS:
+ * - Token must have 'repo' scope (full repository access)
+ * - Test repository must have GitHub Issues enabled
+ * - Repository must have sub-issues feature enabled (GitHub Enterprise or beta)
+ * - If you get HTTP 403 errors, check token permissions and repository settings
  */
 
 import type { E2ETestHelper } from './setup'
@@ -66,11 +72,11 @@ describe('Sub-issue Management - E2E', () => {
     ], config)
 
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Sub-issue')
-    expect(result.stdout).toContain('created')
+    expect(result.stdout).toMatch(/created|linked/i)
 
     // Extract created issue number from output
-    const match = result.stdout.match(/#(\d+)/)
+    // Output format: "Sub-issue #38 created and linked to #29!"
+    const match = result.stdout.match(/Sub-issue #(\d+) created/)
     expect(match).toBeTruthy()
 
     if (match) {
@@ -102,7 +108,7 @@ describe('Sub-issue Management - E2E', () => {
     ], config)
 
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('linked as sub-issue')
+    expect(result.stdout).toMatch(/sub-issue linked successfully/i)
 
     console.log(`✓ Linked #${childIssueNumber} as sub-issue of #${parentIssueNumber}`)
   })
@@ -123,7 +129,7 @@ describe('Sub-issue Management - E2E', () => {
     ], config)
 
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Sub-issues of')
+    expect(result.stdout).toMatch(/sub-issue/i)
     expect(result.stdout).toContain(`#${childIssueNumber}`)
 
     console.log(`✓ Listed sub-issues of #${parentIssueNumber}`)


### PR DESCRIPTION
## Summary

Fixes E2E test infrastructure issues and migrates to a manual-only testing strategy to conserve API rate limits.

### Issues Fixed
- ✅ Issue creation returning `undefined` (labels parameter format)
- ✅ Tests using installed extension instead of local build
- ✅ Missing `--repo` flag causing wrong repository usage
- ✅ Test assertions not matching current command output

### Key Changes

**Test Infrastructure** (`test/e2e/setup.ts`):
- Fix `createTestIssue()` to use correct labels array format (`labels[]=label`)
- Add error handling with exit code and response validation
- Update `runE2ECommand()` to execute local build via `bun run dist/index.js`
- Auto-append `--repo` flag to ensure correct repository usage
- Update default repository to `pleaseai/gh-please-e2e`

**Test Assertions**:
- Update dependency tests to match current output format
- Fix sub-issue number extraction regex
- Use flexible regex patterns instead of exact string matching

**CI/CD Strategy**:
- Remove automatic E2E tests from `ci.yml`
- Keep `manual-e2e.yml` for on-demand testing
- **Benefits**: Saves API rate limits, reduces test repo pollution, run only when needed

**Documentation** (`test/e2e/README.md` - NEW):
- Comprehensive setup guide with GitHub PAT requirements
- Environment variable configuration
- Troubleshooting section for HTTP 403 and other common errors
- Manual workflow usage guide
- Test coverage overview and development guide

### Test Results

```bash
✅ All E2E tests: 14 pass, 0 fail (37 assertions)
  - Dependency tests: 8/8 pass
  - Sub-issue tests: 6/6 pass

✅ All unit tests: 326 pass, 0 fail (678 assertions)
✅ Type check: passed
✅ Lint: passed
```

### Breaking Changes

None - E2E tests are opt-in and don't affect regular CI workflow.

### Migration Guide

To run E2E tests:

**Locally**:
```bash
export GITHUB_TEST_TOKEN=ghp_your_token
bun test test/e2e/
```

**GitHub Actions**:
1. Add `GH_PLEASE_TEST_TOKEN` secret to repository
2. Go to Actions → Manual E2E Tests → Run workflow

See `test/e2e/README.md` for detailed setup instructions.