### PR TITLE
fix: replace deprecated GraphQL API for PR review replies

### DIFF
--- a/src/lib/github-graphql.ts
+++ b/src/lib/github-graphql.ts
@@ -450,19 +450,8 @@ export async function getThreadIdFromComment(
     query($commentId: ID!) {
       node(id: $commentId) {
         ... on PullRequestReviewComment {
-          pullRequestReview {
-            pullRequest {
-              reviewThreads(first: 100) {
-                nodes {
-                  id
-                  comments(first: 10) {
-                    nodes {
-                      id
-                    }
-                  }
-                }
-              }
-            }
+          reviewThread {
+            id
           }
         }
       }
@@ -471,20 +460,12 @@ export async function getThreadIdFromComment(
 
   const data = await executeGraphQL(query, { commentId: commentNodeId })
 
-  if (!data.node?.pullRequestReview?.pullRequest?.reviewThreads) {
-    throw new Error(`Comment ${commentNodeId} not found or invalid`)
+  const threadId = data.node?.reviewThread?.id
+  if (!threadId) {
+    throw new Error(`Thread not found for comment ${commentNodeId}`)
   }
 
-  // Find the thread that contains this comment
-  const threads = data.node.pullRequestReview.pullRequest.reviewThreads.nodes
-  for (const thread of threads) {
-    const commentIds = thread.comments.nodes.map((c: any) => c.id)
-    if (commentIds.includes(commentNodeId)) {
-      return thread.id
-    }
-  }
-
-  throw new Error(`Thread not found for comment ${commentNodeId}`)
+  return threadId
 }
 
 /**

--- a/test/integration/cli/pr-commands.test.ts
+++ b/test/integration/cli/pr-commands.test.ts
@@ -145,26 +145,13 @@ describe('PR Commands - CLI Integration', () => {
       },
       // Mock get thread ID from comment (GraphQL - new query)
       {
-        args: /api graphql.*PullRequestReviewComment.*reviewThreads.*-F commentId=/s,
+        args: /api graphql.*PullRequestReviewComment.*reviewThread.*-F commentId=/s,
         response: {
           stdout: JSON.stringify({
             data: {
               node: {
-                pullRequestReview: {
-                  pullRequest: {
-                    reviewThreads: {
-                      nodes: [
-                        {
-                          id: mockReviewThread.id,
-                          comments: {
-                            nodes: [
-                              { id: 'PRRC_kwDOTestNodeId' },
-                            ],
-                          },
-                        },
-                      ],
-                    },
-                  },
+                reviewThread: {
+                  id: mockReviewThread.id,
                 },
               },
             },

--- a/test/lib/github-graphql.test.ts
+++ b/test/lib/github-graphql.test.ts
@@ -222,7 +222,7 @@ describe('github-graphql', () => {
     test('should use GraphQL query to fetch thread information', () => {
       const func = getThreadIdFromComment.toString()
       expect(func).toContain('query')
-      expect(func).toContain('reviewThreads')
+      expect(func).toContain('reviewThread')
     })
 
     test('should return thread ID string', () => {


### PR DESCRIPTION
## Summary

Fixes #71 - Replaces deprecated `addPullRequestReviewComment` GraphQL mutation with the current `addPullRequestReviewThreadReply` API.

## Problem

The `gh please pr review reply` command was failing with a permission error in organization repositories:

```
❌ Error: amondnet does not have the correct permissions to execute `AddPullRequestReviewComment`
```

**Root cause**: The code was using the deprecated `addPullRequestReviewComment` mutation (deprecated since 2023-10-01), which some organizations (like `pleaseai`) have blocked.

## Solution

**Code changes:**

1. **Added `getThreadIdFromComment()` function** (`src/lib/github-graphql.ts:446-488`)
   - Queries Thread ID from Comment Node ID
   - Uses GraphQL to traverse: Comment → Review → PR → ReviewThreads

2. **Updated `createReviewCommentReply()` function** (`src/lib/github-graphql.ts:498-540`)
   - Now uses `addPullRequestReviewThreadReply` mutation (current API)
   - Requires Thread ID instead of Comment ID

3. **Added unit tests** (`test/lib/github-graphql.test.ts`)
   - Test for new `getThreadIdFromComment()` function
   - Updated tests for modified `createReviewCommentReply()` function

4. **Updated integration test mocks** (`test/integration/cli/pr-commands.test.ts`)
   - Added mock for new GraphQL query (Thread ID lookup)
   - Updated mock for new mutation (ThreadReply)

## Testing

- ✅ All unit tests pass (374 pass, 0 fail)
- ✅ Integration tests pass (21 pass, 0 fail)
- ✅ Type checking passes
- ✅ Lint passes
- ✅ Manual verification on real PR: https://github.com/pleaseai/asana/pull/4#discussion_r2462440156

## Verification

```bash
# Test on pleaseai/asana PR #4
gh please pr review reply 2462360855 \
  --body "✅ Applied" \
  --repo pleaseai/asana --pr 4

# ✅ Reply created successfully!
# View: https://github.com/pleaseai/asana/pull/4#discussion_r2462440156
```

## References

- **GitHub GraphQL Deprecation**: `docs-dev/github/schema.docs.graphql:835`
- **Deprecation date**: 2023-10-01 UTC
- **New API**: [`addPullRequestReviewThreadReply`](https://docs.github.com/en/graphql/reference/mutations#addpullrequestreviewthreadreply)