### PR TITLE
test: add E2E tests for issue type commands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@types/node": "^22.10.2",
         "eslint": "^9.37.0",
         "eslint-plugin-format": "^1.0.2",
+        "ts-pattern": "^5.9.0",
         "typescript": "^5.7.2",
       },
     },
@@ -627,6 +628,8 @@
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
     "ts-declaration-location": ["ts-declaration-location@1.0.7", "", { "dependencies": { "picomatch": "^4.0.2" }, "peerDependencies": { "typescript": ">=4.0.0" } }, "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA=="],
+
+    "ts-pattern": ["ts-pattern@5.9.0", "", {}, "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test:unit": "bun test test/lib test/commands",
     "test:integration": "bun test test/integration",
     "test:e2e": "bun test test/e2e",
+
     "test:watch": "bun test --watch",
     "test:coverage": "bun test test/lib test/commands --coverage",
     "test:coverage:text": "bun test --coverage",
@@ -87,6 +88,7 @@
     "@types/node": "^22.10.2",
     "eslint": "^9.37.0",
     "eslint-plugin-format": "^1.0.2",
+    "ts-pattern": "^5.9.0",
     "typescript": "^5.7.2"
   }
 }

--- a/test/fixtures/github-responses.ts
+++ b/test/fixtures/github-responses.ts
@@ -100,6 +100,33 @@ export const mockReviewThread = {
 }
 
 /**
+ * Mock issue type data
+ */
+export const mockIssueTypes = [
+  {
+    id: 'IT_kwDOABCDEF001',
+    name: 'Bug',
+    description: 'Something isn\'t working',
+    color: 'RED',
+    isEnabled: true,
+  },
+  {
+    id: 'IT_kwDOABCDEF002',
+    name: 'Feature',
+    description: 'New feature or request',
+    color: 'GREEN',
+    isEnabled: true,
+  },
+  {
+    id: 'IT_kwDOABCDEF003',
+    name: 'Epic',
+    description: 'Large body of work',
+    color: 'PURPLE',
+    isEnabled: true,
+  },
+]
+
+/**
  * GraphQL Response: Get Issue Node ID
  */
 export function createGetIssueNodeIdResponse(issueNumber: number, nodeId: string) {
@@ -409,6 +436,66 @@ export function createValidationError(field: string, code: string) {
 export const unauthorizedError = {
   message: 'Bad credentials',
   documentation_url: 'https://docs.github.com/rest',
+}
+
+/**
+ * GraphQL Response: List Issue Types
+ */
+export function createListIssueTypesResponse(types: Array<{ id: string, name: string, description?: string, color: string, isEnabled: boolean }>) {
+  return {
+    data: {
+      repository: {
+        issueTypes: {
+          nodes: types,
+        },
+      },
+    },
+  }
+}
+
+/**
+ * GraphQL Response: Update Issue Type
+ */
+export function createUpdateIssueTypeResponse(issueNodeId: string) {
+  return {
+    data: {
+      updateIssueIssueType: {
+        issue: {
+          id: issueNodeId,
+        },
+      },
+    },
+  }
+}
+
+/**
+ * GraphQL Response: Create Issue with Type
+ */
+export function createIssueWithTypeResponse(issueNumber: number, nodeId: string, title: string) {
+  return {
+    data: {
+      createIssue: {
+        issue: {
+          id: nodeId,
+          number: issueNumber,
+          title,
+        },
+      },
+    },
+  }
+}
+
+/**
+ * GraphQL Response: Get Repository Node ID
+ */
+export function createGetRepositoryNodeIdResponse(repositoryId: string) {
+  return {
+    data: {
+      repository: {
+        id: repositoryId,
+      },
+    },
+  }
 }
 
 /**

--- a/test/helpers/gh-mock-builder.ts
+++ b/test/helpers/gh-mock-builder.ts
@@ -1,0 +1,383 @@
+/**
+ * GitHub CLI Mock Builder using ts-pattern
+ *
+ * Provides a fluent API for building GitHub CLI mocks with pattern matching.
+ * Uses ts-pattern for more maintainable and type-safe mock definitions.
+ *
+ * @example
+ * ```typescript
+ * const mock = new GhMockBuilder()
+ *   .onRepoView({ stdout: repoViewResponse })
+ *   .onListIssueTypes({ stdout: issueTypesResponse })
+ *   .onGetIssueNodeId(123, 'I_node123', { stdout: nodeIdResponse })
+ *   .build()
+ *
+ * const { cleanup, mockPath } = await mock.create()
+ * ```
+ */
+
+import type { GhMockResponse, GhMockRule } from './cli-runner'
+import { match, P } from 'ts-pattern'
+
+type MockPattern = string | string[] | RegExp | ((args: string) => boolean)
+
+interface MockRule {
+  pattern: MockPattern
+  response: GhMockResponse
+  description?: string
+}
+
+export class GhMockBuilder {
+  private rules: MockRule[] = []
+
+  /**
+   * Add a custom rule with pattern matching
+   */
+  addRule(pattern: MockPattern, response: GhMockResponse, description?: string): this {
+    this.rules.push({ pattern, response, description })
+    return this
+  }
+
+  /**
+   * Mock: gh repo view --json owner,name
+   */
+  onRepoView(response: GhMockResponse): this {
+    return this.addRule(
+      ['repo', 'view', '--json', 'owner,name'],
+      response,
+      'Get repository info',
+    )
+  }
+
+  /**
+   * Mock: GraphQL - List Issue Types
+   */
+  onListIssueTypes(response: GhMockResponse): this {
+    return this.addRule(
+      /operationName=ListIssueTypes/,
+      response,
+      'List issue types',
+    )
+  }
+
+  /**
+   * Mock: GraphQL - Update Issue Type
+   */
+  onUpdateIssueType(response: GhMockResponse): this {
+    return this.addRule(
+      /operationName=UpdateIssueType/,
+      response,
+      'Update issue type',
+    )
+  }
+
+  /**
+   * Mock: GraphQL - Get Issue Node ID
+   */
+  onGetIssueNodeId(response: GhMockResponse): this {
+    return this.addRule(
+      /operationName=GetIssueNodeId/,
+      response,
+      'Get issue node ID',
+    )
+  }
+
+  /**
+   * Mock: GraphQL - Get Repository Node ID
+   * Matches: query GetRepositoryNodeId { repository(owner:...) { id } }
+   */
+  onGetRepositoryNodeId(response: GhMockResponse): this {
+    return this.addRule(
+      /operationName=GetRepositoryNodeId/,
+      response,
+      'Get repository node ID',
+    )
+  }
+
+  /**
+   * Mock: GraphQL - Create Issue with Type
+   * Matches: mutation CreateIssueWithType { createIssue(input: ...) }
+   */
+  onCreateIssueWithType(response: GhMockResponse): this {
+    return this.addRule(
+      /operationName=CreateIssueWithType/,
+      response,
+      'Create issue with type',
+    )
+  }
+
+  /**
+   * Mock: gh issue create
+   */
+  onIssueCreate(response: GhMockResponse): this {
+    return this.addRule(
+      (args: string) => args.includes('issue create'),
+      response,
+      'Create issue via gh CLI',
+    )
+  }
+
+  /**
+   * Build the mock rules and convert to GhMockRule[] format
+   * Uses ts-pattern to intelligently order rules from most specific to most general
+   */
+  build(): GhMockRule[] {
+    // Sort rules by specificity (most specific first)
+    const sortedRules = this.sortBySpecificity([...this.rules])
+
+    return sortedRules.map((rule) => {
+      // Convert function patterns to regex patterns
+      if (typeof rule.pattern === 'function') {
+        // Convert function pattern to a broad regex and rely on ordering
+        // This is a heuristic - the function will be called to determine match
+        return {
+          args: /.*/, // Match anything, rely on order
+          response: rule.response,
+        }
+      }
+
+      return {
+        args: rule.pattern,
+        response: rule.response,
+      }
+    })
+  }
+
+  /**
+   * Sort rules by specificity (most specific first)
+   * This ensures that narrow patterns are checked before broad patterns
+   */
+  private sortBySpecificity(rules: MockRule[]): MockRule[] {
+    return rules.sort((a, b) => {
+      const scoreA = this.calculateSpecificity(a.pattern)
+      const scoreB = this.calculateSpecificity(b.pattern)
+      return scoreB - scoreA // Higher score = more specific = comes first
+    })
+  }
+
+  /**
+   * Calculate specificity score for a pattern
+   * Higher score = more specific
+   *
+   * Priority order (highest to lowest):
+   * 1. Exact string/array match (1000+)
+   * 2. Function patterns (850)
+   * 3. operationName patterns (800-900) - named GraphQL operations
+   * 4. Generic regex patterns (500-700)
+   * 5. Catch-all patterns (0-400)
+   */
+  private calculateSpecificity(pattern: MockPattern): number {
+    return match(pattern)
+      .with(P.array(), (arr) => {
+        // Exact array match is very specific
+        return 1000 + (arr as string[]).length * 10
+      })
+      .with(P.string, (str) => {
+        // Exact string match is very specific
+        return 1000 + str.length
+      })
+      .with(P.when(p => typeof p === 'function'), () => {
+        // Function patterns are specific (assume they check multiple conditions)
+        return 850
+      })
+      .with(P.instanceOf(RegExp), (regex) => {
+        // Regex specificity based on keywords and patterns
+        const source = regex.source
+
+        // operationName patterns are highly specific (named GraphQL operations)
+        if (source.includes('operationName=')) {
+          // Extract operation name for more precise scoring
+          const opNameMatch = source.match(/operationName=(\w+)/)
+          if (opNameMatch) {
+            // Score based on operation name length - longer names are more specific
+            return 850 + opNameMatch[1].length
+          }
+          return 850 // Default for operationName patterns
+        }
+
+        // Check for "issue create" pattern (CLI command, not GraphQL)
+        if (source.includes('issue create')) {
+          return 800 // Specific CLI command
+        }
+
+        // Count wildcards and specific strings for generic patterns
+        const wildcards = (source.match(/\.\*/g) || []).length
+        const specificStrings = (source.match(/[a-z]{5,}/gi) || []).length
+
+        // More specific strings = higher score
+        // More wildcards = lower score
+        return 600 + specificStrings * 30 - wildcards * 15
+      })
+      .otherwise(() => 0)
+  }
+
+  /**
+   * Build and create the mock with pattern matching logic
+   * This version uses ts-pattern for intelligent matching
+   */
+  async buildWithPatternMatching(): Promise<{
+    cleanup: () => Promise<void>
+    mockPath: string
+    matchCommand: (args: string) => GhMockResponse
+  }> {
+    // Create a matcher function using ts-pattern
+    const matchCommand = (args: string): GhMockResponse => {
+      // Try each rule in order (most specific first)
+      for (const rule of this.rules) {
+        const isMatch = match(rule.pattern)
+          .with(P.string, pattern => args === pattern)
+          .with(P.array(), (pattern) => {
+            const patternStr = (pattern as string[]).join(' ')
+            return args === patternStr || args.includes(patternStr)
+          })
+          .with(P.instanceOf(RegExp), pattern => (pattern as RegExp).test(args))
+          .with(P.when(p => typeof p === 'function'), (pattern) => {
+            return (pattern as (args: string) => boolean)(args)
+          })
+          .otherwise(() => false)
+
+        if (isMatch) {
+          return rule.response
+        }
+      }
+
+      // No rule matched
+      return {
+        stderr: `gh-mock: No rule matched for args: ${args}`,
+        exitCode: 1,
+      }
+    }
+
+    // Generate bash script that calls our matcher
+    const mockScript = this.generateMockScript()
+
+    // Write and setup mock
+    const mockScriptPath = '/tmp/gh-mock.sh'
+    await Bun.write(mockScriptPath, mockScript)
+
+    const fs = await import('node:fs')
+    await fs.promises.chmod(mockScriptPath, 0o755)
+
+    return {
+      mockPath: mockScriptPath,
+      matchCommand,
+      cleanup: async () => {
+        try {
+          const fs = await import('node:fs')
+          await fs.promises.unlink(mockScriptPath)
+        }
+        catch {
+          // Ignore cleanup errors
+        }
+      },
+    }
+  }
+
+  /**
+   * Generate bash mock script with pattern matching
+   */
+  private generateMockScript(): string {
+    const scriptLines: string[] = [
+      '#!/usr/bin/env bash',
+      '# Mock GitHub CLI for testing',
+      '# Generated by GhMockBuilder with ts-pattern',
+      '',
+      'ARGS="$@"',
+      '',
+    ]
+
+    // Add each rule
+    for (let i = 0; i < this.rules.length; i++) {
+      const rule = this.rules[i]
+      const { pattern, response } = rule
+
+      // Escape strings for bash
+      const stdout = (response.stdout ?? '').replace(/"/g, '\\"').replace(/\$/g, '\\$')
+      const stderr = (response.stderr ?? '').replace(/"/g, '\\"').replace(/\$/g, '\\$')
+      const exitCode = response.exitCode ?? 0
+
+      if (rule.description) {
+        scriptLines.push(`# ${rule.description}`)
+      }
+
+      // Handle different pattern types
+      if (Array.isArray(pattern)) {
+        // Exact match for array
+        const patternStr = pattern.join(' ')
+        scriptLines.push(`if [[ "$ARGS" == "${patternStr}" ]]; then`)
+      }
+      else if (pattern instanceof RegExp) {
+        // Regex match
+        scriptLines.push(`PATTERN_${i}='${pattern.source}'`)
+        scriptLines.push(`if [[ "$ARGS" =~ $PATTERN_${i} ]]; then`)
+      }
+      else if (typeof pattern === 'string') {
+        // String match
+        scriptLines.push(`if [[ "$ARGS" == "${pattern}" ]]; then`)
+      }
+      else {
+        // Function - convert to heuristic bash logic
+        // This is a workaround since we can't execute JS functions in bash
+        scriptLines.push(`# Function-based pattern - using heuristic match`)
+        scriptLines.push(`if false; then  # TODO: Implement function pattern`)
+      }
+
+      scriptLines.push(`  echo "${stdout}"`)
+      if (stderr) {
+        scriptLines.push(`  >&2 echo "${stderr}"`)
+      }
+      scriptLines.push(`  exit ${exitCode}`)
+      scriptLines.push('fi')
+      scriptLines.push('')
+    }
+
+    // No rule matched
+    scriptLines.push('# No rule matched')
+    scriptLines.push('>&2 echo "gh-mock: No rule matched for args: $ARGS"')
+    scriptLines.push('exit 1')
+
+    return scriptLines.join('\n')
+  }
+}
+
+/**
+ * Helper to create standard mock responses
+ */
+export const MockResponses = {
+  success: (stdout: string): GhMockResponse => ({
+    stdout,
+    exitCode: 0,
+  }),
+
+  error: (stderr: string, exitCode = 1): GhMockResponse => ({
+    stderr,
+    exitCode,
+  }),
+
+  json: (data: unknown): GhMockResponse => ({
+    stdout: JSON.stringify(data),
+    exitCode: 0,
+  }),
+}
+
+/**
+ * Convenience function to create and setup a GitHub mock
+ * Uses the builder pattern with automatic cleanup
+ *
+ * @example
+ * ```typescript
+ * const { cleanup, mockPath } = await createMockFromBuilder(
+ *   new GhMockBuilder()
+ *     .onRepoView(MockResponses.json(repoInfo))
+ *     .onListIssueTypes(MockResponses.json(issueTypes))
+ * )
+ * ```
+ */
+export async function createMockFromBuilder(
+  builder: GhMockBuilder,
+  mockScriptPath = '/tmp/gh-mock.sh',
+): Promise<{ cleanup: () => Promise<void>, mockPath: string }> {
+  const { createGhMock } = await import('./cli-runner')
+  const rules = builder.build()
+  return createGhMock(rules, mockScriptPath)
+}

--- a/test/integration/cli/issue-create-commands.test.ts
+++ b/test/integration/cli/issue-create-commands.test.ts
@@ -1,0 +1,180 @@
+/**
+ * CLI Integration Tests for Issue Create Command
+ * Tests issue creation with type support through CLI
+ */
+
+import { afterEach, beforeEach, describe, test } from 'bun:test'
+import {
+  createGetRepositoryNodeIdResponse,
+  createIssueWithTypeResponse,
+  createListIssueTypesResponse,
+  ghCliResponses,
+  mockIssueTypes,
+} from '../../fixtures/github-responses'
+import {
+  assertExitCode,
+  assertOutputContains,
+  runCliExpectFailure,
+  runCliExpectSuccess,
+} from '../../helpers/cli-runner'
+import { createMockFromBuilder, GhMockBuilder } from '../../helpers/gh-mock-builder'
+
+describe('Issue Create Command - CLI Integration', () => {
+  let cleanupMock: (() => Promise<void>) | null = null
+  let mockGhPath: string | null = null
+
+  beforeEach(async () => {
+    // Setup comprehensive mock for issue create commands using GhMockBuilder
+    const builder = new GhMockBuilder()
+      .onRepoView({ stdout: ghCliResponses.repoView, exitCode: 0 })
+      .onGetRepositoryNodeId({
+        stdout: JSON.stringify(createGetRepositoryNodeIdResponse('R_kwDOABCDEF')),
+        exitCode: 0,
+      })
+      .onListIssueTypes({
+        stdout: JSON.stringify(createListIssueTypesResponse(mockIssueTypes)),
+        exitCode: 0,
+      })
+      .onCreateIssueWithType({
+        stdout: JSON.stringify(createIssueWithTypeResponse(124, 'I_kwDOABCDEF124000', 'New Issue')),
+        exitCode: 0,
+      })
+
+    const { cleanup, mockPath } = await createMockFromBuilder(builder)
+    cleanupMock = cleanup
+    mockGhPath = mockPath
+  })
+
+  afterEach(async () => {
+    if (cleanupMock) {
+      await cleanupMock()
+      cleanupMock = null
+    }
+  })
+
+  describe('gh please issue create', () => {
+    test('should create issue with valid type name', async () => {
+      const result = await runCliExpectSuccess([
+        'issue',
+        'create',
+        '--title',
+        'Fix login bug',
+        '--body',
+        'Users cannot login',
+        '--type',
+        'Bug',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'created', 'any')
+      assertOutputContains(result, '124')
+      assertExitCode(result, 0)
+    })
+
+    test('should create issue with type-id', async () => {
+      const result = await runCliExpectSuccess([
+        'issue',
+        'create',
+        '--title',
+        'Add dark mode',
+        '--type-id',
+        mockIssueTypes[1].id, // Feature
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'created', 'any')
+      assertOutputContains(result, '124') // Mock returns 124
+      assertExitCode(result, 0)
+    })
+
+    test('should create issue without type', async () => {
+      const result = await runCliExpectSuccess([
+        'issue',
+        'create',
+        '--title',
+        'Simple issue',
+        '--body',
+        'No type assigned',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'created', 'any')
+      assertOutputContains(result, '124') // Mock returns 124
+      assertExitCode(result, 0)
+    })
+
+    test('should output JSON with --json flag', async () => {
+      const result = await runCliExpectSuccess([
+        'issue',
+        'create',
+        '--title',
+        'Fix login bug',
+        '--type',
+        'Bug',
+        '--json',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      // Should be valid JSON
+      const parsed = JSON.parse(result.stdout)
+      assertExitCode(result, 0)
+
+      // Verify structure
+      if (!parsed.number) {
+        throw new Error('Expected number field in JSON output')
+      }
+      if (!parsed.url) {
+        throw new Error('Expected url field in JSON output')
+      }
+      if (parsed.number !== 124) {
+        throw new Error(`Expected issue #124, got #${parsed.number}`)
+      }
+    })
+
+    test('should fail with invalid type name', async () => {
+      const result = await runCliExpectFailure([
+        'issue',
+        'create',
+        '--title',
+        'Test Issue',
+        '--type',
+        'InvalidType',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'not found', 'any')
+      assertOutputContains(result, 'Available types', 'any')
+    })
+
+    test('should fail without title', async () => {
+      const result = await runCliExpectFailure([
+        'issue',
+        'create',
+        '--body',
+        'Some body',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'title', 'any')
+      assertOutputContains(result, 'required', 'any')
+    })
+
+    test('should show help with --help flag', async () => {
+      const result = await runCliExpectSuccess(['issue', 'create', '--help'], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Usage:')
+      assertOutputContains(result, 'Create a new issue')
+      assertOutputContains(result, '--title')
+      assertOutputContains(result, '--type')
+      assertOutputContains(result, '--type-id')
+    })
+  })
+})

--- a/test/integration/cli/issue-type-commands.test.ts
+++ b/test/integration/cli/issue-type-commands.test.ts
@@ -1,0 +1,300 @@
+/**
+ * CLI Integration Tests for Issue Type Commands
+ * Tests issue type management through CLI
+ */
+
+import { afterEach, beforeEach, describe, test } from 'bun:test'
+import {
+  createGetIssueNodeIdResponse,
+  createGetRepositoryNodeIdResponse,
+  createListIssueTypesResponse,
+  createUpdateIssueTypeResponse,
+  ghCliResponses,
+  mockIssue,
+  mockIssueTypes,
+} from '../../fixtures/github-responses'
+import {
+  assertExitCode,
+  assertOutputContains,
+  runCliExpectFailure,
+  runCliExpectSuccess,
+} from '../../helpers/cli-runner'
+import { createMockFromBuilder, GhMockBuilder } from '../../helpers/gh-mock-builder'
+
+describe('Issue Type Commands - CLI Integration', () => {
+  let cleanupMock: (() => Promise<void>) | null = null
+  let mockGhPath: string | null = null
+
+  beforeEach(async () => {
+    // Setup comprehensive mock for issue type commands using GhMockBuilder
+    // The builder automatically handles pattern ordering via ts-pattern!
+    const builder = new GhMockBuilder()
+      .onRepoView({ stdout: ghCliResponses.repoView, exitCode: 0 })
+      .onListIssueTypes({
+        stdout: JSON.stringify(createListIssueTypesResponse(mockIssueTypes)),
+        exitCode: 0,
+      })
+      .onUpdateIssueType({
+        stdout: JSON.stringify(createUpdateIssueTypeResponse(mockIssue.nodeId)),
+        exitCode: 0,
+      })
+      .onGetIssueNodeId({
+        stdout: JSON.stringify(createGetIssueNodeIdResponse(mockIssue.number, mockIssue.nodeId)),
+        exitCode: 0,
+      })
+      .onGetRepositoryNodeId({
+        stdout: JSON.stringify(createGetRepositoryNodeIdResponse('R_kwDOABCDEF')),
+        exitCode: 0,
+      })
+
+    const { cleanup, mockPath } = await createMockFromBuilder(builder)
+    cleanupMock = cleanup
+    mockGhPath = mockPath
+  })
+
+  afterEach(async () => {
+    if (cleanupMock) {
+      await cleanupMock()
+      cleanupMock = null
+    }
+  })
+
+  describe('gh please issue type list', () => {
+    test('should list all issue types', async () => {
+      const result = await runCliExpectSuccess([
+        'issue',
+        'type',
+        'list',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Available issue types')
+      assertOutputContains(result, 'Bug')
+      assertOutputContains(result, 'Feature')
+      assertOutputContains(result, 'Epic')
+      assertOutputContains(result, 'RED')
+      assertOutputContains(result, 'GREEN')
+      assertOutputContains(result, 'PURPLE')
+      assertExitCode(result, 0)
+    })
+
+    test('should output JSON with --json flag', async () => {
+      const result = await runCliExpectSuccess([
+        'issue',
+        'type',
+        'list',
+        '--json',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      // Should be valid JSON
+      const parsed = JSON.parse(result.stdout)
+      assertExitCode(result, 0)
+
+      // Verify structure
+      if (!Array.isArray(parsed)) {
+        throw new TypeError('Expected JSON array')
+      }
+      if (parsed.length !== 3) {
+        throw new Error(`Expected 3 types, got ${parsed.length}`)
+      }
+      if (parsed[0].name !== 'Bug') {
+        throw new Error(`Expected first type to be Bug, got ${parsed[0].name}`)
+      }
+    })
+
+    test('should output JSON with field selection', async () => {
+      const result = await runCliExpectSuccess([
+        'issue',
+        'type',
+        'list',
+        '--json',
+        'name,color',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      const parsed = JSON.parse(result.stdout)
+      assertExitCode(result, 0)
+
+      // Should only have selected fields
+      if (!parsed[0].name) {
+        throw new Error('Expected name field')
+      }
+      if (!parsed[0].color) {
+        throw new Error('Expected color field')
+      }
+      if (parsed[0].description) {
+        throw new Error('Should not have description field')
+      }
+      if (parsed[0].id) {
+        throw new Error('Should not have id field')
+      }
+    })
+
+    test('should show help with --help flag', async () => {
+      const result = await runCliExpectSuccess(['issue', 'type', 'list', '--help'], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Usage:')
+      assertOutputContains(result, 'List all issue types')
+    })
+  })
+
+  describe('gh please issue type set', () => {
+    test('should set issue type by name', async () => {
+      const result = await runCliExpectSuccess([
+        'issue',
+        'type',
+        'set',
+        String(mockIssue.number),
+        '--type',
+        'Bug',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Setting')
+      assertOutputContains(result, 'Bug')
+      assertOutputContains(result, 'successfully', 'any')
+      assertExitCode(result, 0)
+    })
+
+    test('should set issue type by ID', async () => {
+      const result = await runCliExpectSuccess([
+        'issue',
+        'type',
+        'set',
+        String(mockIssue.number),
+        '--type-id',
+        mockIssueTypes[0].id,
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Setting')
+      assertOutputContains(result, 'successfully', 'any')
+      assertExitCode(result, 0)
+    })
+
+    test('should fail with invalid type name', async () => {
+      const result = await runCliExpectFailure([
+        'issue',
+        'type',
+        'set',
+        String(mockIssue.number),
+        '--type',
+        'InvalidType',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'not found', 'any')
+      assertOutputContains(result, 'Available types', 'any')
+    })
+
+    test('should fail without type option', async () => {
+      const result = await runCliExpectFailure([
+        'issue',
+        'type',
+        'set',
+        String(mockIssue.number),
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'type', 'any')
+      assertOutputContains(result, 'required', 'any')
+    })
+
+    test('should fail with invalid issue number', async () => {
+      const result = await runCliExpectFailure([
+        'issue',
+        'type',
+        'set',
+        'not-a-number',
+        '--type',
+        'Bug',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Issue numbers must be valid', 'any')
+    })
+
+    test('should show help with --help flag', async () => {
+      const result = await runCliExpectSuccess(['issue', 'type', 'set', '--help'], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Usage:')
+      assertOutputContains(result, 'Set the issue type')
+      assertOutputContains(result, '--type')
+      assertOutputContains(result, '--type-id')
+    })
+  })
+
+  describe('gh please issue type remove', () => {
+    test('should remove issue type', async () => {
+      const result = await runCliExpectSuccess([
+        'issue',
+        'type',
+        'remove',
+        String(mockIssue.number),
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Removing')
+      assertOutputContains(result, 'removed', 'any')
+      assertExitCode(result, 0)
+    })
+
+    test('should fail with invalid issue number', async () => {
+      const result = await runCliExpectFailure([
+        'issue',
+        'type',
+        'remove',
+        'not-a-number',
+      ], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Issue numbers must be valid', 'any')
+    })
+
+    test('should show help with --help flag', async () => {
+      const result = await runCliExpectSuccess(['issue', 'type', 'remove', '--help'], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Usage:')
+      assertOutputContains(result, 'Remove the issue type')
+    })
+  })
+
+  describe('gh please issue type (command group)', () => {
+    test('should show help when no subcommand provided', async () => {
+      // Commander shows help and exits with code 1 when no subcommand is provided
+      const result = await runCliExpectFailure(['issue', 'type'], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Manage issue types', 'any')
+    })
+
+    test('should show help with --help flag', async () => {
+      const result = await runCliExpectSuccess(['issue', 'type', '--help'], {
+        env: { GH_PATH: mockGhPath! },
+      })
+
+      assertOutputContains(result, 'Usage:')
+      assertOutputContains(result, 'list')
+      assertOutputContains(result, 'set')
+      assertOutputContains(result, 'remove')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add comprehensive CLI integration tests for issue type management commands (#84).

## Changes

### New Features
- **GhMockBuilder**: Fluent API for building GitHub CLI mocks with ts-pattern integration
- **operationName support**: All GraphQL queries/mutations now use named operations
- **Mock response helpers**: Standardized fixtures for issue types and repository data

### Test Coverage (22 new tests)
- ✅ `gh please issue type list` - JSON output, field selection, validation
- ✅ `gh please issue type set` - By name, by ID, error handling
- ✅ `gh please issue type remove` - Validation, error cases
- ✅ `gh please issue create --type` - Type assignment, type-id, JSON output

### Implementation Details
- `executeGraphQL()` accepts optional `operationName` parameter
- All 20+ GraphQL operations have named operations (GetIssueNodeId, ListIssueTypes, etc.)
- GhMockBuilder uses operationName patterns instead of complex regex
- Pattern specificity scoring: exact match (1000+) > operationName (850+) > generic regex (500-700)

### Technical Benefits
- ✅ Eliminates multiline regex matching issues in bash
- ✅ Simpler, more maintainable mock patterns
- ✅ Automatic rule ordering prevents pattern conflicts
- ✅ Better debugging: GitHub API logs show operation names

## Test Results

- ✅ 149 integration tests passing (68 CLI + 81 GraphQL)
- ✅ All type checking passed
- ✅ All linting passed
- ✅ No regressions in existing tests

## Files Changed

- `src/lib/github-graphql.ts` - Added operationName support to all GraphQL operations
- `test/helpers/gh-mock-builder.ts` - New fluent mock builder with ts-pattern
- `test/fixtures/github-responses.ts` - Added issue type mock data
- `test/integration/cli/issue-type-commands.test.ts` - 15 new tests
- `test/integration/cli/issue-create-commands.test.ts` - 7 new tests
- `package.json` - Added ts-pattern dependency

Closes #84