### PR TITLE
docs: fix broken links in gh-cli-passthrough documentation

### DIFF
--- a/docs/en/features/gh-cli-passthrough.md
+++ b/docs/en/features/gh-cli-passthrough.md
@@ -297,5 +297,5 @@ done
 
 - [GitHub CLI Manual](https://cli.github.com/manual/) - Complete gh CLI documentation
 - [Output Formatting](https://cli.github.com/manual/gh_help_formatting) - gh CLI format options
-- [TOON Format](./toon-format.md) - Learn about TOON format benefits
-- [JSON Output](./json-output.md) - JSON output in gh-please
+- [TOON Format ADR](../../docs-dev/adr/0006-toon-output-format.md) - TOON format specification and benefits
+- [JSON Output ADR](../../docs-dev/adr/0003-json-output-implementation.md) - JSON output implementation details

--- a/docs/ko/features/gh-cli-passthrough.md
+++ b/docs/ko/features/gh-cli-passthrough.md
@@ -297,5 +297,5 @@ done
 
 - [GitHub CLI 매뉴얼](https://cli.github.com/manual/) - 전체 gh CLI 문서
 - [출력 포맷팅](https://cli.github.com/manual/gh_help_formatting) - gh CLI 형식 옵션
-- [TOON 형식](./toon-format.md) - TOON 형식의 이점 알아보기
-- [JSON 출력](./json-output.md) - gh-please의 JSON 출력
+- [TOON 형식 ADR](../../docs-dev/adr/0006-toon-output-format.md) - TOON 형식 명세 및 이점
+- [JSON 출력 ADR](../../docs-dev/adr/0003-json-output-implementation.md) - JSON 출력 구현 세부사항


### PR DESCRIPTION
- Replace non-existent toon-format.md with ADR 0006 link
- Replace non-existent json-output.md with ADR 0003 link
- Apply fix to both English and Korean documentation