### PR TITLE
refactor: narrow skill description scope to CLI commands

### DIFF
--- a/skills/using-pleaseai-github/SKILL.md
+++ b/skills/using-pleaseai-github/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: using-github-please-extension
-version: 1.1.0
-lastUpdated: 2025-10-30
-description: Automate GitHub workflows with gh-please CLI extension - manage issues, sub-issues, dependencies, PR reviews, and worktrees with LLM-friendly output formats (TOON 58.9% token reduction, JSON, XML, Markdown). Access all 100+ gh CLI commands with automatic format conversion. Use when user mentions gh please, gh CLI commands, TOON format, issue types, sub-issues, dependencies, blocked-by, PR reviews, review threads, comment management, worktree workflow, or GitHub automation.
+version: 1.2.0
+lastUpdated: 2025-10-31
+description: gh-please CLI extension command reference and syntax guide. Enhanced gh CLI replacement providing command syntax, options, and execution examples for sub-issues, dependencies, PR review threads, worktrees, and TOON format output (58.9% token reduction). Use when needing CLI command syntax, 'gh please 명령어', 'gh please 사용법', execution examples, or gh-please specific features. For organizational workflow standards, see your organization's GitHub plugin.
 allowed-tools: Read, Bash, Grep, Glob, Edit, WebFetch
 ---
 


### PR DESCRIPTION
## Summary

This PR refines the Claude Code skill description to focus on CLI command reference, reducing overlap with organization-specific GitHub workflow plugins.

## Problem

The current description is too broad, causing conflicts with organization-specific GitHub plugins that define workflow standards:
- Triggers like "manage issues", "GitHub automation" activate gh-please when users want organizational workflow guidance
- PassionFactory's github plugin defines issue types, label systems, and workflow standards
- gh-please should focus on CLI command execution, not workflow standards

## Solution

**Narrow the description to CLI command reference:**
- Emphasize "command reference and syntax guide"
- Remove workflow/standard-related triggers
- Add reference to organizational plugins for workflow standards
- Include minimal Korean triggers for command syntax

## Changes

### Description Changes
- ✅ **Before**: "Automate GitHub workflows... manage issues, sub-issues..."
- ✅ **After**: "CLI extension command reference and syntax guide..."
- ✅ Added: "For organizational workflow standards, see your organization's GitHub plugin"

### Trigger Changes
- ❌ **Removed**: "manage issues", "GitHub automation", "worktree workflow"
- ✅ **Kept**: "CLI command syntax", "execution examples", "gh-please specific features"
- ✅ **Added (Korean)**: "gh please 명령어", "gh please 사용법"

### Version
- Bumped to 1.2.0

## Benefits

### For All Organizations
- ✅ gh-please remains general-purpose CLI documentation
- ✅ Organizations can maintain separate workflow standards
- ✅ Clear separation: CLI tool vs. workflow guidance

### For PassionFactory
- ✅ "create issue" → activates PassionFactory's github plugin (organizational standards)
- ✅ "gh please command" → activates gh-please (CLI syntax)

### Improved Skill Discovery
- Users get organizational standards when asking about workflows
- Users get CLI syntax when asking about gh-please commands
- No more confusion between the two

## Testing

Tested with PassionFactory's engineering-standards repository:

| User Input | Expected Skill | Result |
|------------|---------------|---------|
| "create issue" | PassionFactory github plugin | ✅ Correct |
| "이슈 생성" | PassionFactory github plugin | ✅ Correct |
| "gh please command" | gh-please | ✅ Correct |
| "gh please 명령어" | gh-please | ✅ Correct |
| "add sub-issue" | gh-please | ✅ Correct (CLI feature) |

## Related

- PassionFactory engineering-standards#62
- Context: PassionFactory maintains organizational GitHub standards in a separate plugin
- This change enables clean separation between CLI tool and organizational standards

## Checklist

- [x] Description focuses on CLI command reference
- [x] Workflow triggers removed
- [x] Organizational plugin reference added
- [x] Korean triggers added (minimal, command-focused)
- [x] Version bumped to 1.2.0
- [x] Tested with organization-specific plugin