### PR TITLE
feat: make TOON default output format (Phase 1.1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,21 +21,6 @@
         "typescript": "^5.7.2",
       },
     },
-    "plugins/ai": {
-      "name": "@pleaseai/gh-please-ai",
-      "version": "1.0.0",
-      "dependencies": {
-        "@clack/prompts": "^0.11.0",
-        "@pleaseai/gh-please": "file:../..",
-        "commander": "^12.1.0",
-      },
-      "devDependencies": {
-        "@antfu/eslint-config": "^6.0.0",
-        "@types/bun": "^1.3.0",
-        "eslint": "^9.37.0",
-        "typescript": "^5.7.2",
-      },
-    },
   },
   "packages": {
     "@antfu/eslint-config": ["@antfu/eslint-config@6.0.0", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@clack/prompts": "^0.11.0", "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0", "@eslint/markdown": "^7.4.0", "@stylistic/eslint-plugin": "^5.4.0", "@typescript-eslint/eslint-plugin": "^8.46.1", "@typescript-eslint/parser": "^8.46.1", "@vitest/eslint-plugin": "^1.3.20", "ansis": "^4.2.0", "cac": "^6.7.14", "eslint-config-flat-gitignore": "^2.1.0", "eslint-flat-config-utils": "^2.1.4", "eslint-merge-processors": "^2.0.0", "eslint-plugin-antfu": "^3.1.1", "eslint-plugin-command": "^3.3.1", "eslint-plugin-import-lite": "^0.3.0", "eslint-plugin-jsdoc": "^59.1.0", "eslint-plugin-jsonc": "^2.21.0", "eslint-plugin-n": "^17.23.1", "eslint-plugin-no-only-tests": "^3.3.0", "eslint-plugin-perfectionist": "^4.15.1", "eslint-plugin-pnpm": "^1.2.0", "eslint-plugin-regexp": "^2.10.0", "eslint-plugin-toml": "^0.12.0", "eslint-plugin-unicorn": "^61.0.2", "eslint-plugin-unused-imports": "^4.2.0", "eslint-plugin-vue": "^10.5.0", "eslint-plugin-yml": "^1.19.0", "eslint-processor-vue-blocks": "^2.0.0", "globals": "^16.4.0", "jsonc-eslint-parser": "^2.4.1", "local-pkg": "^1.1.2", "parse-gitignore": "^2.0.0", "toml-eslint-parser": "^0.10.0", "vue-eslint-parser": "^10.2.0", "yaml-eslint-parser": "^1.3.0" }, "peerDependencies": { "@eslint-react/eslint-plugin": "^2.0.1", "@next/eslint-plugin-next": "^15.4.0-canary.115", "@prettier/plugin-xml": "^3.4.1", "@unocss/eslint-plugin": ">=0.50.0", "astro-eslint-parser": "^1.0.2", "eslint": "^9.10.0", "eslint-plugin-astro": "^1.2.0", "eslint-plugin-format": ">=0.1.0", "eslint-plugin-jsx-a11y": ">=6.10.2", "eslint-plugin-react-hooks": "^7.0.0", "eslint-plugin-react-refresh": "^0.4.19", "eslint-plugin-solid": "^0.14.3", "eslint-plugin-svelte": ">=2.35.1", "eslint-plugin-vuejs-accessibility": "^2.4.1", "prettier-plugin-astro": "^0.14.0", "prettier-plugin-slidev": "^1.0.5", "svelte-eslint-parser": ">=0.37.0" }, "optionalPeers": ["@eslint-react/eslint-plugin", "@next/eslint-plugin-next", "@prettier/plugin-xml", "@unocss/eslint-plugin", "astro-eslint-parser", "eslint-plugin-astro", "eslint-plugin-format", "eslint-plugin-jsx-a11y", "eslint-plugin-react-hooks", "eslint-plugin-react-refresh", "eslint-plugin-solid", "eslint-plugin-svelte", "eslint-plugin-vuejs-accessibility", "prettier-plugin-astro", "prettier-plugin-slidev", "svelte-eslint-parser"], "bin": { "eslint-config": "bin/index.js" } }, "sha512-M2RM+x+hpxpASEZzQh4d5uaUEHn8sYNVlTB+CySpLkDs2rr3QFvRR7KqNdnox/OIPc6YWMsIEnM/XUbQP52nTA=="],
@@ -107,10 +92,6 @@
     "@pkgr/core": ["@pkgr/core@0.1.2", "", {}, "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ=="],
 
     "@pleaseai/cli-toolkit": ["@pleaseai/cli-toolkit@0.2.0", "", { "dependencies": { "@byjohann/toon": "^0.3.0", "commander": "^12.1.0", "es-toolkit": "^1.31.0" }, "peerDependencies": { "typescript": "^5" } }, "sha512-Axx5g7HHBP3ndwfr5zWVZns9iQzXA9xcZ4RQb04UKddtllGQ4aQH7JFbqQVeBHkQ7PpPPD755+FUb5pPMtMpZg=="],
-
-    "@pleaseai/gh-please": ["gh-extension-please@root:", {}],
-
-    "@pleaseai/gh-please-ai": ["@pleaseai/gh-please-ai@workspace:plugins/ai"],
 
     "@stylistic/eslint-plugin": ["@stylistic/eslint-plugin@5.5.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.0", "@typescript-eslint/types": "^8.46.1", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "estraverse": "^5.3.0", "picomatch": "^4.0.3" }, "peerDependencies": { "eslint": ">=9.0.0" } }, "sha512-IeZF+8H0ns6prg4VrkhgL+yrvDXWDH2cKchrbh80ejG9dQgZWp10epHMbgRuQvgchLII/lfh6Xn3lu6+6L86Hw=="],
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -107,6 +107,7 @@ export interface PassthroughMessages {
   jsonParseError: string
   jsonNotSupported: string
   fieldsRequired: string
+  deprecationWarning: string
 }
 
 export const issueMessages: Record<Language, IssueMessages> = {
@@ -341,11 +342,13 @@ export const passthroughMessages: Record<Language, PassthroughMessages> = {
     jsonParseError: '❌ JSON 출력을 파싱할 수 없습니다',
     jsonNotSupported: '❌ 이 명령어는 구조화된 출력을 지원하지 않습니다 (--json 플래그가 없음)',
     fieldsRequired: '❌ 이 명령어는 필드 지정이 필요하지만 필드 매핑이 아직 생성되지 않았습니다',
+    deprecationWarning: '⚠️  네이티브 테이블 출력은 더 이상 사용되지 않습니다. 레거시 출력을 사용하려면 --format table을 사용하세요.\n   TOON 형식이 곧 기본값이 됩니다 (58.9% 토큰 감소).',
   },
   en: {
     jsonParseError: '❌ Failed to parse JSON output',
     jsonNotSupported: '❌ This command does not support structured output (no --json flag available)',
     fieldsRequired: '❌ This command requires field specification but field mapping is not yet generated',
+    deprecationWarning: '⚠️  Native table output is deprecated. Use --format table for legacy output.\n   TOON format will be default soon (58.9% token reduction).',
   },
 }
 


### PR DESCRIPTION
BREAKING CHANGE: Default output is now TOON format instead of native table output

- Add ExtendedFormat type to support 'table' alongside 'toon' and 'json'
- Update shouldConvertToStructuredFormat() to default to 'toon'
- Add --format table flag for legacy native output (deprecated)
- Show deprecation warning when using --format table
- Update passThroughCommand() to handle table format with early return
- Add i18n deprecation warning messages (English/Korean)
- Update all tests to expect TOON as default (48/48 passing)
- Full test suite: 574/574 tests passing

Benefits:
- 58.9% token reduction by default for LLM workflows
- Backward compatibility via --format table
- Clear migration path with deprecation warnings
- Graceful degradation for commands without --json support

Related: #135