### PR TITLE
feat(core): add Node ID universal decoder for offline database ID extraction

### DIFF
--- a/.please/memory/session-summary.md
+++ b/.please/memory/session-summary.md
@@ -1,0 +1,90 @@
+# Session Summary: Node ID Universal Decoder
+
+## Feature Description
+GitHub Node ID를 Database ID, Legacy Node ID, New Node ID 형식 간에 자유롭게 변환하는 기능 구현.
+API 호출 없이 로컬에서 직접 디코딩/인코딩하여 빠르고 오프라인에서도 사용 가능.
+
+## Requirements
+1. **Node ID 디코딩**: New 형식(MessagePack+Base64)과 Legacy 형식(텍스트 Base64) 모두 지원
+2. **Database ID 추출**: Node ID에서 Database ID 직접 추출
+3. **API 없이 동작**: 로컬 디코딩으로 빠르고 오프라인 지원
+4. **기존 코드 통합**: 현재 id-converter.ts에 기능 확장
+
+## Constraints
+- Bun 런타임 사용 (Node.js 아님)
+- 기존 isNodeId(), isDatabaseId() 함수와 호환
+- MessagePack 디코딩을 위한 의존성 최소화
+
+## Current Phase
+**Phase 2: Codebase Exploration** - 완료
+
+## Codebase Analysis Results
+
+### 현재 ID 변환 구현
+- **파일**: `src/lib/id-converter.ts` (199 lines)
+- **핵심 함수**: `isNodeId()`, `isDatabaseId()`, `toReviewCommentNodeId()`, `toIssueCommentNodeId()`
+- **한계**: REST API 호출로 Node ID 조회 → 추가 API 호출 필요
+
+### Node ID 사용 위치 (GraphQL 필수)
+- `src/lib/github/review-operations.ts` - 리뷰 코멘트 답글/수정
+- `src/lib/github/issue-hierarchy.ts` - 서브이슈, 의존성 관리
+- `src/lib/github/graphql-core.ts` - GraphQL 쿼리 실행
+
+### Database ID 사용 위치 (REST API)
+- `src/lib/github-api.ts` - REST API 엔드포인트 구성
+- `src/types.ts` - 인터페이스 정의
+
+### MessagePack 디코딩 분석 결과
+1. **순수 JS 구현 가능**: ~30줄로 GitHub Node ID 디코딩 가능
+2. **Bun 지원**: `atob()`, `Buffer.from()` 모두 사용 가능
+3. **라이브러리 옵션**: `@msgpack/msgpack` (20KB), `msgpack.js` (2.7KB)
+4. **권장**: 순수 JS 구현 (의존성 없음, GitHub ID에 충분)
+
+### 핵심 파일 (읽어야 할 파일)
+1. src/lib/id-converter.ts - 기존 ID 변환 유틸리티
+2. src/lib/github/graphql-core.ts - GraphQL 코어
+3. src/lib/github/review-operations.ts - 리뷰 작업
+4. test/lib/id-converter.test.ts - 기존 테스트 패턴
+5. docs-dev/adr/0005-id-converter-utility.md - 설계 의사결정
+
+## Key Decisions
+- API 없이 로컬 디코딩 방식 선택 (사용자 확인 완료)
+- 순수 JS 구현 선택 (의존성 0, ~50줄 코드)
+
+## Architecture Design
+
+### 선택된 접근 방식: 순수 JavaScript 구현
+
+**구조:**
+```
+src/lib/
+├── id-converter.ts        # 기존 파일 (확장)
+└── node-id-decoder.ts     # 새 파일 (핵심 디코딩 로직)
+```
+
+**핵심 함수:**
+1. `decodeNodeId(nodeId)` - Node ID 디코딩 (New/Legacy 형식 자동 감지)
+2. `extractDatabaseId(nodeId)` - Database ID만 추출
+3. `getNodeIdType(nodeId)` - 타입 문자열 반환
+
+**MessagePack 디코딩 범위:**
+- fixarray (0x90-0x9f): 배열 헤더
+- positive fixint (0x00-0x7f): 작은 정수
+- uint32 (0xce): 4바이트 정수
+
+**Node ID Prefix 매핑:**
+```typescript
+const PREFIX_MAP = {
+  I_: 'Issue',
+  PR_: 'PullRequest',
+  IC_: 'IssueComment',
+  PRRC_: 'PullRequestReviewComment',
+  PRRT_: 'PullRequestReviewThread',
+  R_: 'Repository',
+  // ... 추가 가능
+}
+```
+
+## Reference
+- Greptile Blog: https://www.greptile.com/blog/github-ids
+- 기존 코드: src/lib/id-converter.ts

--- a/.please/memory/tasklist.json
+++ b/.please/memory/tasklist.json
@@ -1,0 +1,32 @@
+{
+  "session_id": "2026-01-15-2317-node-id-decoder",
+  "feature_name": "Node ID Universal Decoder",
+  "created_at": "2026-01-15T23:17:00+09:00",
+  "updated_at": "2026-01-15T23:28:00+09:00",
+  "status": "in_progress",
+  "current_phase": 6,
+  "issue_number": 244,
+  "phases": [
+    { "number": 1, "name": "Discovery", "status": "completed", "started_at": "2026-01-15T23:17:00+09:00", "completed_at": "2026-01-15T23:18:00+09:00" },
+    { "number": 2, "name": "Codebase Exploration", "status": "completed", "started_at": "2026-01-15T23:18:00+09:00", "completed_at": "2026-01-15T23:22:00+09:00" },
+    { "number": 3, "name": "Specification & Clarification", "status": "completed", "started_at": "2026-01-15T23:22:00+09:00", "completed_at": "2026-01-15T23:24:00+09:00" },
+    { "number": 4, "name": "Architecture Design", "status": "completed", "started_at": "2026-01-15T23:24:00+09:00", "completed_at": "2026-01-15T23:26:00+09:00" },
+    { "number": 5, "name": "GitHub Issue & PR", "status": "completed", "started_at": "2026-01-15T23:26:00+09:00", "completed_at": "2026-01-15T23:28:00+09:00" },
+    { "number": 6, "name": "Implementation", "status": "in_progress", "started_at": "2026-01-15T23:28:00+09:00" },
+    { "number": 7, "name": "Quality Review", "status": "pending" },
+    { "number": 8, "name": "PR Finalization", "status": "pending" }
+  ],
+  "tasks": [
+    { "id": "T001", "title": "Create src/lib/node-id-decoder.ts with MessagePack decoder", "phase": 6, "status": "pending", "parallel": true, "dependencies": [] },
+    { "id": "T002", "title": "Create test/lib/node-id-decoder.test.ts with unit tests", "phase": 6, "status": "pending", "parallel": true, "dependencies": [] },
+    { "id": "T003", "title": "Integrate decoder into src/lib/id-converter.ts", "phase": 6, "status": "pending", "parallel": false, "dependencies": ["T001"] },
+    { "id": "T004", "title": "Update test/lib/id-converter.test.ts", "phase": 6, "status": "pending", "parallel": false, "dependencies": ["T002", "T003"] },
+    { "id": "T005", "title": "Update docs-dev/GITHUB_ID_SYSTEMS.md documentation", "phase": 6, "status": "pending", "parallel": false, "dependencies": ["T003"] }
+  ],
+  "checkpoint_config": {
+    "mode": "auto",
+    "push_strategy": "batch",
+    "validation_required": true
+  },
+  "checkpoints": []
+}

--- a/docs-dev/GITHUB_ID_SYSTEMS.md
+++ b/docs-dev/GITHUB_ID_SYSTEMS.md
@@ -76,6 +76,49 @@ GraphQL's universal identifier, required for types without Database ID.
 - **REST API**: Returned as `node_id` field
 - **GraphQL API**: Primary identifier (`id` field), `node(id: "...")` queries
 
+### Node ID Formats
+
+GitHub uses two Node ID formats:
+
+#### New Format (MessagePack + Base64)
+- **Pattern**: `PREFIX_base64EncodedMessagePack`
+- **Example**: `PRRC_kwDOL4aMSs6Tkzl8`
+- **Structure**: MessagePack array `[version, repositoryId, databaseId]`
+- **Prefixes**: `I_` (Issue), `PR_` (PullRequest), `IC_` (IssueComment), `PRRC_` (PullRequestReviewComment), `PRRT_` (PullRequestReviewThread), `R_` (Repository), etc.
+
+#### Legacy Format (Text Base64)
+- **Pattern**: Base64-encoded `"XXX:TypeNameDatabaseId"`
+- **Example**: `MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=` (decodes to `"010:Repository139095377"`)
+- **Used by**: Older repositories (pre-2011)
+
+### Offline Node ID Decoding
+
+gh-please provides **offline Node ID decoding** without API calls:
+
+```typescript
+import { decodeNodeId, extractDatabaseId } from 'gh-please/lib/id-converter'
+
+// Decode New format Node ID
+const result = decodeNodeId('PRRC_kwDOL4aMSs6Tkzl8')
+// → { type: 'PullRequestReviewComment', databaseId: 2475899260, repositoryId: 797346890, format: 'new' }
+
+// Decode Legacy format Node ID
+const legacy = decodeNodeId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')
+// → { type: 'Repository', databaseId: 139095377, format: 'legacy' }
+
+// Extract only Database ID
+const dbId = extractDatabaseId('PRRC_kwDOL4aMSs6Tkzl8')
+// → 2475899260
+```
+
+**Benefits**:
+- No API calls required
+- Works offline
+- Instant response (synchronous)
+- Supports both New and Legacy formats
+
+**Reference**: See [Greptile Blog: GitHub IDs](https://www.greptile.com/blog/github-ids) for the original research.
+
 **Usage in gh-please**:
 ```bash
 # Thread operations - Node ID required (GraphQL-only type)

--- a/docs-dev/GITHUB_ID_SYSTEMS.md
+++ b/docs-dev/GITHUB_ID_SYSTEMS.md
@@ -111,11 +111,41 @@ const dbId = extractDatabaseId('PRRC_kwDOL4aMSs6Tkzl8')
 // → 2475899260
 ```
 
+### Offline Node ID Encoding
+
+gh-please also provides **offline Node ID encoding** (Database ID → Node ID):
+
+```typescript
+import { encodeNodeId } from 'gh-please/lib/id-converter'
+
+// Encode using type name
+const nodeId = encodeNodeId({
+  type: 'PullRequestReviewComment',
+  repositoryId: 797346890,
+  databaseId: 2475899260,
+})
+// → 'PRRC_kwDOL4aMSs6Tkzl8'
+
+// Encode using prefix
+const nodeId2 = encodeNodeId({
+  prefix: 'I_',
+  repositoryId: 797346890,
+  databaseId: 123456,
+})
+// → 'I_kwDOL4aMSs4AAeJA'
+```
+
+**Requirements for encoding**:
+- `type` or `prefix`: Specifies the GitHub entity type
+- `repositoryId`: The repository's database ID (available from decoded Node IDs)
+- `databaseId`: The entity's database ID to encode
+
 **Benefits**:
 - No API calls required
 - Works offline
 - Instant response (synchronous)
-- Supports both New and Legacy formats
+- Supports both New and Legacy formats (decoding)
+- Roundtrip safe: `decode(encode(x)) === x`
 
 **Reference**: See [Greptile Blog: GitHub IDs](https://www.greptile.com/blog/github-ids) for the original research.
 

--- a/specs/001-node-id-decoder/spec.md
+++ b/specs/001-node-id-decoder/spec.md
@@ -1,0 +1,115 @@
+# Node ID Universal Decoder
+
+## Summary
+GitHub Node ID를 로컬에서 디코딩하여 Database ID를 추출하고, 다양한 Node ID 형식(Legacy, New)을 모두 지원하는 유틸리티 함수 구현.
+
+## Background
+GitHub의 모든 객체는 두 가지 ID를 가진다:
+- **Database ID**: 정수형 (예: `2475899260`)
+- **Node ID**: Base64 인코딩된 문자열 (예: `PRRC_kwDOL4aMSs6Tkzl8`)
+
+현재 gh-please의 id-converter.ts는 REST API를 호출하여 Node ID를 조회한다. 이 방식은 추가 API 호출이 필요하고, 오프라인에서 사용할 수 없다.
+
+## Goals
+1. Node ID에서 Database ID를 API 호출 없이 로컬에서 추출
+2. Legacy Node ID 형식(Base64 텍스트)과 New 형식(MessagePack) 모두 지원
+3. 기존 id-converter.ts 함수들과 통합
+
+## Non-Goals
+- Node ID 생성/인코딩 (현재는 디코딩만)
+- GraphQL API 변경
+- 사용자 인터페이스(CLI) 변경
+
+## Requirements
+
+### Functional Requirements
+
+#### FR1: New Node ID 디코딩
+- 형식: `PREFIX_kwDO...` (MessagePack + Base64)
+- 추출 데이터: `[version, repository_id, object_id]`
+- Database ID = object_id (배열의 마지막 요소)
+
+#### FR2: Legacy Node ID 디코딩
+- 형식: `MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=` (텍스트 Base64)
+- 디코딩 결과: `010:Repository139095377`
+- Database ID = 문자열에서 숫자 추출
+
+#### FR3: Prefix 검증
+- 지원 Prefix: `I_`, `PR_`, `IC_`, `PRRC_`, `PRRT_`, `R_` 등
+- 알 수 없는 Prefix는 에러 발생
+
+#### FR4: 기존 함수 통합
+- `toReviewCommentNodeId()`: 먼저 로컬 디코딩 시도, 실패 시 기존 API 호출
+- `toIssueCommentNodeId()`: 동일한 패턴 적용
+
+### Non-Functional Requirements
+
+#### NFR1: 의존성 최소화
+- 외부 MessagePack 라이브러리 없이 순수 JS로 구현
+- Bun 내장 API(atob, Buffer) 활용
+
+#### NFR2: 성능
+- 디코딩은 동기식, 즉시 반환 (API 호출 없음)
+- 메모리 할당 최소화
+
+#### NFR3: 하위 호환성
+- 기존 함수 시그니처 유지
+- 기존 테스트 통과
+
+## API Design
+
+```typescript
+// 새로운 함수
+export function decodeNodeId(nodeId: string): DecodedNodeId
+export function extractDatabaseId(nodeId: string): number
+export function getNodeIdType(nodeId: string): string | null
+
+// 타입 정의
+export interface DecodedNodeId {
+  type: string // 'Issue', 'PullRequest', 'IssueComment', etc.
+  prefix: string // 'I_', 'PR_', 'IC_', 'PRRC_', etc.
+  databaseId: number // 추출된 Database ID
+  format: 'new' | 'legacy'
+  repositoryId?: number // New 형식에서만 존재
+  raw: number[] // New 형식의 원시 배열 [version, repoId, objectId]
+}
+```
+
+## Test Cases
+
+### TC1: New Format Decoding
+```typescript
+decodeNodeId('PRRC_kwDOL4aMSs6Tkzl8')
+// → { type: 'PullRequestReviewComment', prefix: 'PRRC_', databaseId: 2475899260, ... }
+```
+
+### TC2: Legacy Format Decoding
+```typescript
+decodeNodeId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')
+// → { type: 'Repository', databaseId: 139095377, format: 'legacy' }
+```
+
+### TC3: Invalid Node ID
+```typescript
+decodeNodeId('invalid')
+// → throws Error('Invalid Node ID format')
+```
+
+### TC4: Database ID Extraction
+```typescript
+extractDatabaseId('IC_kwDOABC123')
+// → 123456789 (number)
+```
+
+## Edge Cases
+
+1. **빈 문자열**: 에러 발생
+2. **Database ID 입력**: 에러 발생 (숫자는 Node ID가 아님)
+3. **손상된 Base64**: 에러 발생
+4. **알 수 없는 Prefix**: 에러 발생 (또는 null 반환)
+5. **매우 큰 Database ID**: BigInt 고려 필요 (현재는 Number로 충분)
+
+## References
+- [Greptile Blog: GitHub IDs](https://www.greptile.com/blog/github-ids)
+- [MessagePack Specification](https://github.com/msgpack/msgpack/blob/master/spec.md)
+- [GitHub Global Node IDs](https://docs.github.com/en/graphql/guides/migrating-graphql-global-node-ids)

--- a/src/lib/id-converter.ts
+++ b/src/lib/id-converter.ts
@@ -8,16 +8,17 @@ import {
   isNewNodeId as isNew,
 } from './node-id-decoder'
 
-// Re-export Node ID decoder functions for offline ID conversion
+// Re-export Node ID decoder/encoder functions for offline ID conversion
 export {
   decodeNodeId,
+  encodeNodeId,
   extractDatabaseId,
   getNodeIdPrefix,
   getNodeIdType,
   isLegacyNodeId,
   isNewNodeId,
 } from './node-id-decoder'
-export type { DecodedNodeId } from './node-id-decoder'
+export type { DecodedNodeId, EncodeNodeIdOptions } from './node-id-decoder'
 
 export type GitHubEntityType = 'review-comment' | 'issue-comment' | 'issue' | 'pull-request'
 

--- a/src/lib/id-converter.ts
+++ b/src/lib/id-converter.ts
@@ -3,6 +3,22 @@
  * Converts between Database ID and Node ID for various GitHub entities
  */
 
+import {
+  isLegacyNodeId as isLegacy,
+  isNewNodeId as isNew,
+} from './node-id-decoder'
+
+// Re-export Node ID decoder functions for offline ID conversion
+export {
+  decodeNodeId,
+  extractDatabaseId,
+  getNodeIdPrefix,
+  getNodeIdType,
+  isLegacyNodeId,
+  isNewNodeId,
+} from './node-id-decoder'
+export type { DecodedNodeId } from './node-id-decoder'
+
 export type GitHubEntityType = 'review-comment' | 'issue-comment' | 'issue' | 'pull-request'
 
 /**
@@ -14,15 +30,15 @@ function getGhCommand(): string {
 }
 
 /**
- * Detect if identifier is a Node ID
- * Node ID patterns: PRRC_xxx (PR Review Comment), IC_xxx (Issue Comment), I_xxx (Issue), PR_xxx (Pull Request)
+ * Detect if identifier is a Node ID (New or Legacy format)
+ * New format: PRRC_xxx, IC_xxx, I_xxx, PR_xxx (prefix + Base64)
+ * Legacy format: Base64-encoded "XXX:TypeNameDatabaseId"
  *
  * @param identifier - String to check
  * @returns True if identifier matches Node ID format
  */
 export function isNodeId(identifier: string): boolean {
-  // Node ID format: 1-4 uppercase letters, underscore, then alphanumeric/dash/underscore
-  return /^[A-Z]{1,4}_[\w-]+$/.test(identifier)
+  return isNew(identifier) || isLegacy(identifier)
 }
 
 /**

--- a/src/lib/node-id-decoder.ts
+++ b/src/lib/node-id-decoder.ts
@@ -1,0 +1,371 @@
+/**
+ * GitHub Node ID Universal Decoder
+ *
+ * Decodes GitHub Node IDs to extract Database IDs without API calls.
+ * Supports both New format (MessagePack + Base64) and Legacy format (text Base64).
+ *
+ * Reference: https://www.greptile.com/blog/github-ids
+ */
+
+/**
+ * Node ID prefix to type mapping
+ */
+const PREFIX_TO_TYPE: Record<string, string> = {
+  I_: 'Issue',
+  PR_: 'PullRequest',
+  IC_: 'IssueComment',
+  PRRC_: 'PullRequestReviewComment',
+  PRRT_: 'PullRequestReviewThread',
+  R_: 'Repository',
+  U_: 'User',
+  O_: 'Organization',
+  RE_: 'Release',
+  C_: 'Commit',
+  LA_: 'Label',
+  MI_: 'Milestone',
+  MDC_: 'Discussion',
+  DC_: 'DiscussionComment',
+}
+
+/**
+ * Legacy type ID to type name mapping
+ * Format: "XXX:TypeNameDatabaseId"
+ */
+const LEGACY_TYPE_PATTERNS: Array<{ pattern: RegExp, type: string }> = [
+  { pattern: /Repository(\d+)$/, type: 'Repository' },
+  { pattern: /Issue(\d+)$/, type: 'Issue' },
+  { pattern: /PullRequest(\d+)$/, type: 'PullRequest' },
+  { pattern: /User(\d+)$/, type: 'User' },
+  { pattern: /Organization(\d+)$/, type: 'Organization' },
+  { pattern: /IssueComment(\d+)$/, type: 'IssueComment' },
+  { pattern: /PullRequestReviewComment(\d+)$/, type: 'PullRequestReviewComment' },
+  { pattern: /Commit(\d+)$/, type: 'Commit' },
+  { pattern: /Release(\d+)$/, type: 'Release' },
+  { pattern: /Label(\d+)$/, type: 'Label' },
+  { pattern: /Milestone(\d+)$/, type: 'Milestone' },
+]
+
+/**
+ * Decoded Node ID result
+ */
+export interface DecodedNodeId {
+  /** GitHub type (e.g., 'Issue', 'PullRequest', 'IssueComment') */
+  type: string | null
+  /** Prefix for New format (e.g., 'I_', 'PR_', 'PRRC_'), null for Legacy */
+  prefix: string | null
+  /** Extracted Database ID */
+  databaseId: number
+  /** Node ID format: 'new' (MessagePack) or 'legacy' (text Base64) */
+  format: 'new' | 'legacy'
+  /** Repository ID (only available in New format) */
+  repositoryId?: number
+  /** Raw decoded array for New format [version, repositoryId, objectId] */
+  raw?: number[]
+}
+
+/**
+ * Check if a string is a New format Node ID (with prefix)
+ * New format: PREFIX_base64EncodedMessagePack
+ */
+export function isNewNodeId(identifier: string): boolean {
+  if (!identifier || typeof identifier !== 'string') {
+    return false
+  }
+  // New format has 1-4 uppercase letters, underscore, then Base64 content
+  return /^[A-Z]{1,4}_[\w-]+$/.test(identifier)
+}
+
+/**
+ * Check if a string is a Legacy format Node ID (plain Base64)
+ * Legacy format: base64 encoded "XXX:TypeNameDatabaseId"
+ */
+export function isLegacyNodeId(identifier: string): boolean {
+  if (!identifier || typeof identifier !== 'string') {
+    return false
+  }
+
+  // Must not be New format
+  if (isNewNodeId(identifier)) {
+    return false
+  }
+
+  // Must be valid Base64 and decode to legacy pattern
+  try {
+    const decoded = decodeBase64ToString(identifier)
+    // Legacy format: "XXX:TypeNameDatabaseId" (e.g., "010:Repository139095377")
+    return /^\d+:[A-Z][a-zA-Z]+\d+$/.test(decoded)
+  }
+  catch {
+    return false
+  }
+}
+
+/**
+ * Get the prefix from a New format Node ID
+ * Returns null for Legacy format or invalid strings
+ */
+export function getNodeIdPrefix(identifier: string): string | null {
+  if (!isNewNodeId(identifier)) {
+    return null
+  }
+  const underscoreIndex = identifier.indexOf('_')
+  return identifier.substring(0, underscoreIndex + 1)
+}
+
+/**
+ * Get the type from a Node ID
+ * Returns null if type cannot be determined
+ */
+export function getNodeIdType(identifier: string): string | null {
+  // Try New format first
+  const prefix = getNodeIdPrefix(identifier)
+  if (prefix) {
+    return PREFIX_TO_TYPE[prefix] ?? null
+  }
+
+  // Try Legacy format
+  if (isLegacyNodeId(identifier)) {
+    try {
+      const decoded = decodeBase64ToString(identifier)
+      for (const { pattern, type } of LEGACY_TYPE_PATTERNS) {
+        if (pattern.test(decoded)) {
+          return type
+        }
+      }
+    }
+    catch {
+      return null
+    }
+  }
+
+  return null
+}
+
+/**
+ * Decode a Node ID to extract all information
+ * Supports both New format (MessagePack) and Legacy format (text Base64)
+ *
+ * @throws Error if the Node ID is invalid or cannot be decoded
+ */
+export function decodeNodeId(nodeId: string): DecodedNodeId {
+  if (!nodeId || typeof nodeId !== 'string') {
+    throw new Error('Invalid Node ID: empty or not a string')
+  }
+
+  // Check if it's a numeric string (Database ID, not Node ID)
+  if (/^\d+$/.test(nodeId)) {
+    throw new Error('Invalid Node ID: numeric strings are Database IDs, not Node IDs')
+  }
+
+  // Try New format first
+  if (isNewNodeId(nodeId)) {
+    return decodeNewFormatNodeId(nodeId)
+  }
+
+  // Try Legacy format
+  if (isLegacyNodeId(nodeId)) {
+    return decodeLegacyFormatNodeId(nodeId)
+  }
+
+  throw new Error(`Invalid Node ID format: "${nodeId}"`)
+}
+
+/**
+ * Extract only the Database ID from a Node ID
+ * Convenience function when only the Database ID is needed
+ *
+ * @throws Error if the Node ID is invalid
+ */
+export function extractDatabaseId(nodeId: string): number {
+  const decoded = decodeNodeId(nodeId)
+  return decoded.databaseId
+}
+
+// ============================================================================
+// Internal Functions
+// ============================================================================
+
+/**
+ * Decode Base64 string to bytes (Uint8Array)
+ * Handles both standard and URL-safe Base64
+ */
+function decodeBase64ToBytes(base64: string): Uint8Array {
+  // Convert URL-safe Base64 to standard Base64
+  const standardBase64 = base64
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+
+  // Add padding if needed
+  const paddedBase64 = standardBase64 + '='.repeat((4 - standardBase64.length % 4) % 4)
+
+  // Decode using atob (available in Bun)
+  const binaryString = atob(paddedBase64)
+  const bytes = new Uint8Array(binaryString.length)
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i)
+  }
+  return bytes
+}
+
+/**
+ * Decode Base64 string to text string (for Legacy format)
+ */
+function decodeBase64ToString(base64: string): string {
+  // Convert URL-safe Base64 to standard Base64
+  const standardBase64 = base64
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+
+  // Add padding if needed
+  const paddedBase64 = standardBase64 + '='.repeat((4 - standardBase64.length % 4) % 4)
+
+  return atob(paddedBase64)
+}
+
+/**
+ * Decode New format Node ID (MessagePack + Base64)
+ * Structure: [version, repositoryId, objectId]
+ */
+function decodeNewFormatNodeId(nodeId: string): DecodedNodeId {
+  const prefix = getNodeIdPrefix(nodeId)!
+  const type = PREFIX_TO_TYPE[prefix] ?? null
+
+  // Extract the Base64 part (after the prefix)
+  const underscoreIndex = nodeId.indexOf('_')
+  const base64Part = nodeId.substring(underscoreIndex + 1)
+
+  try {
+    const bytes = decodeBase64ToBytes(base64Part)
+    const decoded = decodeMessagePackArray(bytes)
+
+    // Expected format: [version, repositoryId, objectId]
+    if (decoded.length < 3) {
+      throw new Error('Invalid MessagePack array: expected at least 3 elements')
+    }
+
+    const repositoryId = decoded[1]!
+    const objectId = decoded[2]!
+
+    return {
+      type,
+      prefix,
+      databaseId: objectId,
+      format: 'new',
+      repositoryId,
+      raw: decoded,
+    }
+  }
+  catch (error) {
+    throw new Error(`Failed to decode Node ID "${nodeId}": ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+/**
+ * Decode Legacy format Node ID (text Base64)
+ * Structure: "XXX:TypeNameDatabaseId"
+ */
+function decodeLegacyFormatNodeId(nodeId: string): DecodedNodeId {
+  try {
+    const decoded = decodeBase64ToString(nodeId)
+
+    // Parse "XXX:TypeNameDatabaseId"
+    const colonIndex = decoded.indexOf(':')
+    if (colonIndex === -1) {
+      throw new Error('Invalid Legacy format: missing colon separator')
+    }
+
+    const typeAndId = decoded.substring(colonIndex + 1)
+
+    // Find where the type name ends and the ID begins
+    const match = typeAndId.match(/^([A-Z][a-zA-Z]+)(\d+)$/)
+    if (!match) {
+      throw new Error('Invalid Legacy format: cannot parse type and ID')
+    }
+
+    const typeName = match[1]!
+    const databaseId = Number.parseInt(match[2]!, 10)
+
+    return {
+      type: typeName,
+      prefix: null,
+      databaseId,
+      format: 'legacy',
+    }
+  }
+  catch (error) {
+    throw new Error(`Failed to decode Legacy Node ID "${nodeId}": ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+/**
+ * Minimal MessagePack decoder for GitHub Node IDs
+ * Only supports formats used by GitHub:
+ * - fixarray (0x90-0x9f): small arrays
+ * - positive fixint (0x00-0x7f): small positive integers
+ * - uint32 (0xce): 32-bit unsigned integers
+ * - uint16 (0xcd): 16-bit unsigned integers
+ * - uint8 (0xcc): 8-bit unsigned integers
+ */
+function decodeMessagePackArray(bytes: Uint8Array): number[] {
+  if (bytes.length === 0) {
+    throw new Error('Empty MessagePack data')
+  }
+
+  let pos = 0
+
+  // Read array header
+  const header = bytes[pos++]!
+
+  // Check for fixarray (0x90-0x9f)
+  if ((header & 0xF0) !== 0x90) {
+    throw new Error(`Expected fixarray, got 0x${header.toString(16)}`)
+  }
+
+  const arrayLength = header & 0x0F
+  const result: number[] = []
+
+  // Read each element
+  for (let i = 0; i < arrayLength; i++) {
+    if (pos >= bytes.length) {
+      throw new Error('Unexpected end of MessagePack data')
+    }
+
+    const type = bytes[pos++]!
+
+    if (type <= 0x7F) {
+      // Positive fixint (0x00-0x7f)
+      result.push(type)
+    }
+    else if (type === 0xCC) {
+      // uint8
+      if (pos >= bytes.length) {
+        throw new Error('Unexpected end of MessagePack data')
+      }
+      result.push(bytes[pos++]!)
+    }
+    else if (type === 0xCD) {
+      // uint16 (big-endian)
+      if (pos + 1 >= bytes.length) {
+        throw new Error('Unexpected end of MessagePack data')
+      }
+      const value = (bytes[pos]! << 8) | bytes[pos + 1]!
+      pos += 2
+      result.push(value)
+    }
+    else if (type === 0xCE) {
+      // uint32 (big-endian)
+      if (pos + 3 >= bytes.length) {
+        throw new Error('Unexpected end of MessagePack data')
+      }
+      const value = (bytes[pos]! << 24) | (bytes[pos + 1]! << 16) | (bytes[pos + 2]! << 8) | bytes[pos + 3]!
+      pos += 4
+      // Convert to unsigned
+      result.push(value >>> 0)
+    }
+    else {
+      throw new Error(`Unsupported MessagePack type: 0x${type.toString(16)}`)
+    }
+  }
+
+  return result
+}

--- a/src/lib/node-id-decoder.ts
+++ b/src/lib/node-id-decoder.ts
@@ -28,6 +28,13 @@ const PREFIX_TO_TYPE: Record<string, string> = {
 }
 
 /**
+ * Type to prefix mapping (reverse of PREFIX_TO_TYPE)
+ */
+const TYPE_TO_PREFIX: Record<string, string> = Object.fromEntries(
+  Object.entries(PREFIX_TO_TYPE).map(([prefix, type]) => [type, prefix]),
+)
+
+/**
  * Legacy type ID to type name mapping
  * Format: "XXX:TypeNameDatabaseId"
  */
@@ -44,6 +51,20 @@ const LEGACY_TYPE_PATTERNS: Array<{ pattern: RegExp, type: string }> = [
   { pattern: /Label(\d+)$/, type: 'Label' },
   { pattern: /Milestone(\d+)$/, type: 'Milestone' },
 ]
+
+/**
+ * Options for encoding a Node ID
+ */
+export interface EncodeNodeIdOptions {
+  /** GitHub type (e.g., 'Issue', 'PullRequest', 'IssueComment') - provide this OR prefix */
+  type?: string
+  /** Node ID prefix (e.g., 'I_', 'PR_', 'PRRC_') - provide this OR type */
+  prefix?: string
+  /** Repository ID (required for New format) */
+  repositoryId: number
+  /** Database ID to encode */
+  databaseId: number
+}
 
 /**
  * Decoded Node ID result
@@ -179,6 +200,64 @@ export function decodeNodeId(nodeId: string): DecodedNodeId {
 export function extractDatabaseId(nodeId: string): number {
   const decoded = decodeNodeId(nodeId)
   return decoded.databaseId
+}
+
+/**
+ * Encode a Node ID from its components (Database ID → Node ID)
+ * Creates a New format Node ID (MessagePack + Base64)
+ *
+ * @param options - Encoding options (type or prefix, repositoryId, databaseId)
+ * @returns Encoded Node ID string
+ * @throws Error if options are invalid
+ *
+ * @example
+ * // Using type
+ * encodeNodeId({ type: 'Issue', repositoryId: 797346890, databaseId: 123 })
+ * // → 'I_kwDOL4aMSs4AAABz'
+ *
+ * @example
+ * // Using prefix
+ * encodeNodeId({ prefix: 'PRRC_', repositoryId: 797346890, databaseId: 2475899260 })
+ * // → 'PRRC_kwDOL4aMSs6Tkzl8'
+ */
+export function encodeNodeId(options: EncodeNodeIdOptions): string {
+  const { type, prefix: inputPrefix, repositoryId, databaseId } = options
+
+  // Resolve prefix from type or use provided prefix
+  let prefix: string
+  if (inputPrefix) {
+    if (!PREFIX_TO_TYPE[inputPrefix]) {
+      throw new Error(`Unknown Node ID prefix: "${inputPrefix}"`)
+    }
+    prefix = inputPrefix
+  }
+  else if (type) {
+    const resolvedPrefix = TYPE_TO_PREFIX[type]
+    if (!resolvedPrefix) {
+      throw new Error(`Unknown type: "${type}". Valid types: ${Object.keys(TYPE_TO_PREFIX).join(', ')}`)
+    }
+    prefix = resolvedPrefix
+  }
+  else {
+    throw new Error('Either type or prefix must be provided')
+  }
+
+  // Validate numeric values
+  if (repositoryId < 0 || !Number.isInteger(repositoryId)) {
+    throw new Error(`Invalid repositoryId: ${repositoryId}. Must be a non-negative integer.`)
+  }
+  if (databaseId < 0 || !Number.isInteger(databaseId)) {
+    throw new Error(`Invalid databaseId: ${databaseId}. Must be a non-negative integer.`)
+  }
+
+  // Encode as MessagePack array: [version, repositoryId, databaseId]
+  const version = 0 // GitHub uses version 0
+  const messagePackBytes = encodeMessagePackArray([version, repositoryId, databaseId])
+
+  // Encode as URL-safe Base64
+  const base64 = encodeBytesToBase64(messagePackBytes)
+
+  return prefix + base64
 }
 
 // ============================================================================
@@ -368,4 +447,113 @@ function decodeMessagePackArray(bytes: Uint8Array): number[] {
   }
 
   return result
+}
+
+/**
+ * Minimal MessagePack encoder for GitHub Node IDs
+ * Encodes an array of numbers to MessagePack format
+ *
+ * Supports:
+ * - fixarray (0x90-0x9f): small arrays (up to 15 elements)
+ * - positive fixint (0x00-0x7f): small positive integers (0-127)
+ * - uint8 (0xcc): 8-bit unsigned integers (128-255)
+ * - uint16 (0xcd): 16-bit unsigned integers (256-65535)
+ * - uint32 (0xce): 32-bit unsigned integers (65536-4294967295)
+ */
+function encodeMessagePackArray(values: number[]): Uint8Array {
+  if (values.length > 15) {
+    throw new Error('Array too large for fixarray format (max 15 elements)')
+  }
+
+  // Calculate total byte size needed
+  let totalSize = 1 // fixarray header
+  for (const value of values) {
+    totalSize += getMessagePackIntSize(value)
+  }
+
+  const bytes = new Uint8Array(totalSize)
+  let pos = 0
+
+  // Write fixarray header (0x90 | length)
+  bytes[pos++] = 0x90 | values.length
+
+  // Write each value
+  for (const value of values) {
+    pos = writeMessagePackInt(bytes, pos, value)
+  }
+
+  return bytes
+}
+
+/**
+ * Get the byte size needed to encode an integer in MessagePack format
+ */
+function getMessagePackIntSize(value: number): number {
+  if (value < 0) {
+    throw new Error('Negative integers not supported')
+  }
+  if (value <= 0x7F) {
+    return 1 // positive fixint
+  }
+  if (value <= 0xFF) {
+    return 2 // uint8
+  }
+  if (value <= 0xFFFF) {
+    return 3 // uint16
+  }
+  if (value <= 0xFFFFFFFF) {
+    return 5 // uint32
+  }
+  throw new Error('Integer too large for uint32')
+}
+
+/**
+ * Write an integer to a Uint8Array in MessagePack format
+ * Returns the new position after writing
+ */
+function writeMessagePackInt(bytes: Uint8Array, pos: number, value: number): number {
+  if (value <= 0x7F) {
+    // Positive fixint
+    bytes[pos++] = value
+  }
+  else if (value <= 0xFF) {
+    // uint8
+    bytes[pos++] = 0xCC
+    bytes[pos++] = value
+  }
+  else if (value <= 0xFFFF) {
+    // uint16 (big-endian)
+    bytes[pos++] = 0xCD
+    bytes[pos++] = (value >> 8) & 0xFF
+    bytes[pos++] = value & 0xFF
+  }
+  else {
+    // uint32 (big-endian)
+    bytes[pos++] = 0xCE
+    bytes[pos++] = (value >> 24) & 0xFF
+    bytes[pos++] = (value >> 16) & 0xFF
+    bytes[pos++] = (value >> 8) & 0xFF
+    bytes[pos++] = value & 0xFF
+  }
+  return pos
+}
+
+/**
+ * Encode bytes to URL-safe Base64 (without padding)
+ */
+function encodeBytesToBase64(bytes: Uint8Array): string {
+  // Convert to binary string
+  let binaryString = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binaryString += String.fromCharCode(bytes[i]!)
+  }
+
+  // Encode to standard Base64
+  const base64 = btoa(binaryString)
+
+  // Convert to URL-safe Base64 (replace + with -, / with _, remove padding =)
+  return base64
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
 }

--- a/src/lib/node-id-decoder.ts
+++ b/src/lib/node-id-decoder.ts
@@ -265,17 +265,24 @@ export function encodeNodeId(options: EncodeNodeIdOptions): string {
 // ============================================================================
 
 /**
- * Decode Base64 string to bytes (Uint8Array)
- * Handles both standard and URL-safe Base64
+ * Prepares a Base64 string for decoding by handling URL-safe characters and padding.
  */
-function decodeBase64ToBytes(base64: string): Uint8Array {
+function prepareBase64(base64: string): string {
   // Convert URL-safe Base64 to standard Base64
   const standardBase64 = base64
     .replace(/-/g, '+')
     .replace(/_/g, '/')
 
   // Add padding if needed
-  const paddedBase64 = standardBase64 + '='.repeat((4 - standardBase64.length % 4) % 4)
+  return standardBase64 + '='.repeat((4 - standardBase64.length % 4) % 4)
+}
+
+/**
+ * Decode Base64 string to bytes (Uint8Array)
+ * Handles both standard and URL-safe Base64
+ */
+function decodeBase64ToBytes(base64: string): Uint8Array {
+  const paddedBase64 = prepareBase64(base64)
 
   // Decode using atob (available in Bun)
   const binaryString = atob(paddedBase64)
@@ -290,14 +297,7 @@ function decodeBase64ToBytes(base64: string): Uint8Array {
  * Decode Base64 string to text string (for Legacy format)
  */
 function decodeBase64ToString(base64: string): string {
-  // Convert URL-safe Base64 to standard Base64
-  const standardBase64 = base64
-    .replace(/-/g, '+')
-    .replace(/_/g, '/')
-
-  // Add padding if needed
-  const paddedBase64 = standardBase64 + '='.repeat((4 - standardBase64.length % 4) % 4)
-
+  const paddedBase64 = prepareBase64(base64)
   return atob(paddedBase64)
 }
 

--- a/test/lib/id-converter.test.ts
+++ b/test/lib/id-converter.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 import {
+  decodeNodeId,
+  extractDatabaseId,
+  getNodeIdPrefix,
+  getNodeIdType,
   isDatabaseId,
+  isLegacyNodeId,
+  isNewNodeId,
   isNodeId,
   toIssueCommentNodeId,
   toReviewCommentNodeId,
@@ -33,6 +39,12 @@ describe('id-converter', () => {
       expect(isNodeId('invalid-id')).toBe(false)
       expect(isNodeId('123abc')).toBe(false)
       expect(isNodeId('')).toBe(false)
+    })
+
+    test('should detect Legacy format Node ID', () => {
+      // Legacy format: Base64-encoded "XXX:TypeNameDatabaseId"
+      expect(isNodeId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe(true) // "010:Repository139095377"
+      expect(isNodeId('MDQ6VXNlcjEyMzQ1')).toBe(true) // "04:User12345"
     })
   })
 
@@ -191,6 +203,50 @@ describe('id-converter', () => {
           expect(error.message.length).toBeGreaterThan(0)
         }
       }
+    })
+  })
+
+  // Tests for re-exported node-id-decoder functions
+  describe('re-exported decoder functions', () => {
+    test('isNewNodeId should detect New format', () => {
+      expect(isNewNodeId('PRRC_kwDOP34zbs6ShH0J')).toBe(true)
+      expect(isNewNodeId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe(false)
+    })
+
+    test('isLegacyNodeId should detect Legacy format', () => {
+      expect(isLegacyNodeId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe(true)
+      expect(isLegacyNodeId('PRRC_kwDOP34zbs6ShH0J')).toBe(false)
+    })
+
+    test('getNodeIdPrefix should extract prefix', () => {
+      expect(getNodeIdPrefix('PRRC_kwDOP34zbs6ShH0J')).toBe('PRRC_')
+      expect(getNodeIdPrefix('IC_kwDOABC123')).toBe('IC_')
+      expect(getNodeIdPrefix('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe(null)
+    })
+
+    test('getNodeIdType should return type', () => {
+      expect(getNodeIdType('PRRC_kwDOP34zbs6ShH0J')).toBe('PullRequestReviewComment')
+      expect(getNodeIdType('IC_kwDOABC123')).toBe('IssueComment')
+      expect(getNodeIdType('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe('Repository')
+    })
+
+    test('decodeNodeId should decode New format', () => {
+      const result = decodeNodeId('PRRC_kwDOL4aMSs6Tkzl8')
+      expect(result.format).toBe('new')
+      expect(result.type).toBe('PullRequestReviewComment')
+      expect(result.databaseId).toBe(2475899260)
+    })
+
+    test('decodeNodeId should decode Legacy format', () => {
+      const result = decodeNodeId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')
+      expect(result.format).toBe('legacy')
+      expect(result.type).toBe('Repository')
+      expect(result.databaseId).toBe(139095377)
+    })
+
+    test('extractDatabaseId should return database ID', () => {
+      expect(extractDatabaseId('PRRC_kwDOL4aMSs6Tkzl8')).toBe(2475899260)
+      expect(extractDatabaseId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe(139095377)
     })
   })
 })

--- a/test/lib/id-converter.test.ts
+++ b/test/lib/id-converter.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 import {
   decodeNodeId,
+  encodeNodeId,
   extractDatabaseId,
   getNodeIdPrefix,
   getNodeIdType,
@@ -247,6 +248,26 @@ describe('id-converter', () => {
     test('extractDatabaseId should return database ID', () => {
       expect(extractDatabaseId('PRRC_kwDOL4aMSs6Tkzl8')).toBe(2475899260)
       expect(extractDatabaseId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe(139095377)
+    })
+
+    test('encodeNodeId should encode Database ID to Node ID', () => {
+      const result = encodeNodeId({
+        type: 'PullRequestReviewComment',
+        repositoryId: 797346890,
+        databaseId: 2475899260,
+      })
+      expect(result).toBe('PRRC_kwDOL4aMSs6Tkzl8')
+    })
+
+    test('encodeNodeId roundtrip should preserve Node ID', () => {
+      const original = 'I_kwDOL4aMSs6Aw-LK'
+      const decoded = decodeNodeId(original)
+      const reencoded = encodeNodeId({
+        type: decoded.type!,
+        repositoryId: decoded.repositoryId!,
+        databaseId: decoded.databaseId,
+      })
+      expect(reencoded).toBe(original)
     })
   })
 })

--- a/test/lib/node-id-decoder.test.ts
+++ b/test/lib/node-id-decoder.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  decodeNodeId,
+  extractDatabaseId,
+  getNodeIdPrefix,
+  getNodeIdType,
+  isLegacyNodeId,
+  isNewNodeId,
+} from '../../src/lib/node-id-decoder'
+
+describe('node-id-decoder', () => {
+  describe('isNewNodeId', () => {
+    test('should detect New format Node ID with prefix', () => {
+      expect(isNewNodeId('PRRC_kwDOL4aMSs6Tkzl8')).toBe(true)
+      expect(isNewNodeId('IC_kwDOABC123')).toBe(true)
+      expect(isNewNodeId('I_kwDOABC123')).toBe(true)
+      expect(isNewNodeId('PR_kwDOABC123')).toBe(true)
+      expect(isNewNodeId('R_kwDOABC123')).toBe(true)
+    })
+
+    test('should reject Legacy format Node ID', () => {
+      // Legacy format: plain Base64 without prefix
+      expect(isNewNodeId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe(false)
+    })
+
+    test('should reject invalid strings', () => {
+      expect(isNewNodeId('invalid')).toBe(false)
+      expect(isNewNodeId('123456')).toBe(false)
+      expect(isNewNodeId('')).toBe(false)
+    })
+  })
+
+  describe('isLegacyNodeId', () => {
+    test('should detect Legacy format Node ID', () => {
+      // Legacy format: "010:Repository139095377" encoded in Base64
+      expect(isLegacyNodeId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe(true)
+      expect(isLegacyNodeId('MDQ6VXNlcjE=')).toBe(true) // "04:User1"
+    })
+
+    test('should reject New format Node ID', () => {
+      expect(isLegacyNodeId('PRRC_kwDOL4aMSs6Tkzl8')).toBe(false)
+      expect(isLegacyNodeId('IC_kwDOABC123')).toBe(false)
+    })
+
+    test('should reject invalid strings', () => {
+      expect(isLegacyNodeId('invalid')).toBe(false)
+      expect(isLegacyNodeId('123456')).toBe(false)
+      expect(isLegacyNodeId('')).toBe(false)
+    })
+  })
+
+  describe('getNodeIdPrefix', () => {
+    test('should extract prefix from New format Node ID', () => {
+      expect(getNodeIdPrefix('PRRC_kwDOL4aMSs6Tkzl8')).toBe('PRRC_')
+      expect(getNodeIdPrefix('IC_kwDOABC123')).toBe('IC_')
+      expect(getNodeIdPrefix('I_kwDOABC123')).toBe('I_')
+      expect(getNodeIdPrefix('PR_kwDOABC123')).toBe('PR_')
+    })
+
+    test('should return null for Legacy format', () => {
+      expect(getNodeIdPrefix('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe(null)
+    })
+
+    test('should return null for invalid strings', () => {
+      expect(getNodeIdPrefix('invalid')).toBe(null)
+      expect(getNodeIdPrefix('')).toBe(null)
+    })
+  })
+
+  describe('getNodeIdType', () => {
+    test('should return type for New format Node ID', () => {
+      expect(getNodeIdType('PRRC_kwDOL4aMSs6Tkzl8')).toBe('PullRequestReviewComment')
+      expect(getNodeIdType('IC_kwDOABC123')).toBe('IssueComment')
+      expect(getNodeIdType('I_kwDOABC123')).toBe('Issue')
+      expect(getNodeIdType('PR_kwDOABC123')).toBe('PullRequest')
+      expect(getNodeIdType('R_kwDOABC123')).toBe('Repository')
+      expect(getNodeIdType('PRRT_kwDOABC123')).toBe('PullRequestReviewThread')
+    })
+
+    test('should extract type from Legacy format', () => {
+      // Legacy "010:Repository139095377"
+      expect(getNodeIdType('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe('Repository')
+    })
+
+    test('should return null for unknown prefix', () => {
+      expect(getNodeIdType('UNKNOWN_kwDOABC123')).toBe(null)
+    })
+
+    test('should return null for invalid strings', () => {
+      expect(getNodeIdType('invalid')).toBe(null)
+      expect(getNodeIdType('')).toBe(null)
+    })
+  })
+
+  describe('decodeNodeId', () => {
+    describe('New format (MessagePack)', () => {
+      test('should decode PR review comment Node ID', () => {
+        // PRRC_kwDOL4aMSs6Tkzl8 decodes to [0, 797346890, 2475899260]
+        const result = decodeNodeId('PRRC_kwDOL4aMSs6Tkzl8')
+
+        expect(result.format).toBe('new')
+        expect(result.prefix).toBe('PRRC_')
+        expect(result.type).toBe('PullRequestReviewComment')
+        expect(result.databaseId).toBe(2475899260)
+        expect(result.repositoryId).toBe(797346890)
+        expect(result.raw).toEqual([0, 797346890, 2475899260])
+      })
+
+      test('should decode Issue Node ID', () => {
+        // I_kwDOL4aMSs6Aw-LK decodes to [0, 797346890, 2160321226]
+        const result = decodeNodeId('I_kwDOL4aMSs6Aw-LK')
+
+        expect(result.format).toBe('new')
+        expect(result.prefix).toBe('I_')
+        expect(result.type).toBe('Issue')
+        expect(result.databaseId).toBe(2160321226)
+        expect(result.repositoryId).toBe(797346890)
+      })
+
+      test('should handle URL-safe Base64', () => {
+        // Node IDs may use URL-safe Base64 (- and _ instead of + and /)
+        const result = decodeNodeId('I_kwDOL4aMSs6Aw-LK')
+        expect(result.databaseId).toBeGreaterThan(0)
+      })
+    })
+
+    describe('Legacy format (text Base64)', () => {
+      test('should decode Legacy Repository Node ID', () => {
+        // "010:Repository139095377" in Base64
+        const result = decodeNodeId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')
+
+        expect(result.format).toBe('legacy')
+        expect(result.prefix).toBe(null)
+        expect(result.type).toBe('Repository')
+        expect(result.databaseId).toBe(139095377)
+        expect(result.repositoryId).toBeUndefined()
+      })
+
+      test('should decode Legacy User Node ID', () => {
+        // "04:User12345" in Base64
+        const result = decodeNodeId('MDQ6VXNlcjEyMzQ1')
+
+        expect(result.format).toBe('legacy')
+        expect(result.type).toBe('User')
+        expect(result.databaseId).toBe(12345)
+      })
+
+      test('should decode Legacy Issue Node ID', () => {
+        // "012:Issue1000" in Base64
+        const result = decodeNodeId('MDEyOklzc3VlMTAwMA==')
+
+        expect(result.format).toBe('legacy')
+        expect(result.type).toBe('Issue')
+        expect(result.databaseId).toBe(1000)
+      })
+    })
+
+    describe('error cases', () => {
+      test('should throw for invalid Node ID', () => {
+        expect(() => decodeNodeId('invalid')).toThrow()
+        expect(() => decodeNodeId('')).toThrow()
+      })
+
+      test('should throw for Database ID (numeric string)', () => {
+        expect(() => decodeNodeId('123456789')).toThrow()
+      })
+
+      test('should throw for corrupted Base64', () => {
+        expect(() => decodeNodeId('PRRC_!@#$%')).toThrow()
+      })
+    })
+  })
+
+  describe('extractDatabaseId', () => {
+    test('should extract Database ID from New format', () => {
+      expect(extractDatabaseId('PRRC_kwDOL4aMSs6Tkzl8')).toBe(2475899260)
+    })
+
+    test('should extract Database ID from Legacy format', () => {
+      expect(extractDatabaseId('MDEwOlJlcG9zaXRvcnkxMzkwOTUzNzc=')).toBe(139095377)
+    })
+
+    test('should throw for invalid Node ID', () => {
+      expect(() => extractDatabaseId('invalid')).toThrow()
+    })
+  })
+})

--- a/test/lib/node-id-decoder.test.ts
+++ b/test/lib/node-id-decoder.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   decodeNodeId,
+  encodeNodeId,
   extractDatabaseId,
   getNodeIdPrefix,
   getNodeIdType,
@@ -182,6 +183,159 @@ describe('node-id-decoder', () => {
 
     test('should throw for invalid Node ID', () => {
       expect(() => extractDatabaseId('invalid')).toThrow()
+    })
+  })
+
+  describe('encodeNodeId', () => {
+    describe('basic encoding', () => {
+      test('should encode Node ID with type string', () => {
+        const result = encodeNodeId({
+          type: 'PullRequestReviewComment',
+          repositoryId: 797346890,
+          databaseId: 2475899260,
+        })
+
+        expect(result).toMatch(/^PRRC_/)
+        expect(isNewNodeId(result)).toBe(true)
+      })
+
+      test('should encode Node ID with prefix string', () => {
+        const result = encodeNodeId({
+          prefix: 'PRRC_',
+          repositoryId: 797346890,
+          databaseId: 2475899260,
+        })
+
+        expect(result).toMatch(/^PRRC_/)
+        expect(isNewNodeId(result)).toBe(true)
+      })
+
+      test('should encode Issue Node ID', () => {
+        const result = encodeNodeId({
+          type: 'Issue',
+          repositoryId: 797346890,
+          databaseId: 2160321226,
+        })
+
+        expect(result).toMatch(/^I_/)
+        expect(isNewNodeId(result)).toBe(true)
+      })
+
+      test('should encode various types', () => {
+        const types = [
+          { type: 'Issue', prefix: 'I_' },
+          { type: 'PullRequest', prefix: 'PR_' },
+          { type: 'IssueComment', prefix: 'IC_' },
+          { type: 'Repository', prefix: 'R_' },
+          { type: 'User', prefix: 'U_' },
+        ]
+
+        for (const { type, prefix } of types) {
+          const result = encodeNodeId({
+            type,
+            repositoryId: 123456,
+            databaseId: 789012,
+          })
+          expect(result.startsWith(prefix)).toBe(true)
+        }
+      })
+    })
+
+    describe('roundtrip encoding/decoding', () => {
+      test('should roundtrip PRRC Node ID', () => {
+        const original = 'PRRC_kwDOL4aMSs6Tkzl8'
+        const decoded = decodeNodeId(original)
+
+        const reencoded = encodeNodeId({
+          type: decoded.type!,
+          repositoryId: decoded.repositoryId!,
+          databaseId: decoded.databaseId,
+        })
+
+        expect(reencoded).toBe(original)
+      })
+
+      test('should roundtrip Issue Node ID', () => {
+        const original = 'I_kwDOL4aMSs6Aw-LK'
+        const decoded = decodeNodeId(original)
+
+        const reencoded = encodeNodeId({
+          type: decoded.type!,
+          repositoryId: decoded.repositoryId!,
+          databaseId: decoded.databaseId,
+        })
+
+        expect(reencoded).toBe(original)
+      })
+
+      test('should roundtrip with small numbers', () => {
+        const encoded = encodeNodeId({
+          type: 'Issue',
+          repositoryId: 100,
+          databaseId: 50,
+        })
+
+        const decoded = decodeNodeId(encoded)
+
+        expect(decoded.type).toBe('Issue')
+        expect(decoded.repositoryId).toBe(100)
+        expect(decoded.databaseId).toBe(50)
+      })
+
+      test('should roundtrip with large numbers', () => {
+        const encoded = encodeNodeId({
+          type: 'PullRequestReviewComment',
+          repositoryId: 4294967295, // Max uint32
+          databaseId: 4294967295,
+        })
+
+        const decoded = decodeNodeId(encoded)
+
+        expect(decoded.type).toBe('PullRequestReviewComment')
+        expect(decoded.repositoryId).toBe(4294967295)
+        expect(decoded.databaseId).toBe(4294967295)
+      })
+    })
+
+    describe('error cases', () => {
+      test('should throw for unknown type', () => {
+        expect(() => encodeNodeId({
+          type: 'UnknownType',
+          repositoryId: 123,
+          databaseId: 456,
+        })).toThrow()
+      })
+
+      test('should throw for unknown prefix', () => {
+        expect(() => encodeNodeId({
+          prefix: 'UNKNOWN_',
+          repositoryId: 123,
+          databaseId: 456,
+        })).toThrow()
+      })
+
+      test('should throw when neither type nor prefix provided', () => {
+        expect(() => encodeNodeId({
+          repositoryId: 123,
+          databaseId: 456,
+        } as any)).toThrow()
+      })
+
+      test('should throw for negative databaseId', () => {
+        expect(() => encodeNodeId({
+          type: 'Issue',
+          repositoryId: 123,
+          databaseId: -1,
+        })).toThrow()
+      })
+
+      test('should throw for negative repositoryId', () => {
+        expect(() => encodeNodeId({
+          type: 'Issue',
+          repositoryId: -1,
+          databaseId: 456,
+        })).toThrow()
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary
- Node ID를 API 호출 없이 로컬에서 디코딩하여 Database ID를 추출하는 유틸리티 함수 구현
- **NEW**: Database ID → Node ID 인코딩 기능 추가 (`encodeNodeId`)
- New 형식(MessagePack+Base64)과 Legacy 형식(텍스트 Base64) 모두 지원
- 순수 JavaScript로 MessagePack 인코더/디코더 구현 (외부 의존성 없음)

## Changes
- `src/lib/node-id-decoder.ts`: Node ID 디코더/인코더 핵심 구현
  - `decodeNodeId()`: Node ID 전체 정보 디코딩
  - `encodeNodeId()`: Database ID → Node ID 인코딩 ✨ **NEW**
  - `extractDatabaseId()`: Database ID만 추출
  - `isNewNodeId()`, `isLegacyNodeId()`: 형식 감지
  - `getNodeIdType()`, `getNodeIdPrefix()`: 타입/프리픽스 추출
- `src/lib/id-converter.ts`: 디코더/인코더 함수 통합 및 re-export
- `test/lib/node-id-decoder.test.ts`: 38개 단위 테스트
- `test/lib/id-converter.test.ts`: 통합 테스트 추가
- `docs-dev/GITHUB_ID_SYSTEMS.md`: 오프라인 디코딩/인코딩 문서 추가

## Test plan
- [x] bun test 전체 통과 (766 pass)
- [x] bun run lint:fix 통과
- [x] bun run type-check 통과
- [x] New 형식 Node ID 디코딩 테스트
- [x] Legacy 형식 Node ID 디코딩 테스트
- [x] Node ID 인코딩 테스트 (type/prefix 입력)
- [x] 라운드트립 테스트 (decode → encode → 원본과 일치)
- [x] 잘못된 입력에 대한 에러 처리 테스트

## Usage Examples

### Decoding (Node ID → Database ID)
```typescript
import { decodeNodeId, extractDatabaseId } from 'gh-please/lib/id-converter'

decodeNodeId('PRRC_kwDOL4aMSs6Tkzl8')
// → { type: 'PullRequestReviewComment', databaseId: 2475899260, repositoryId: 797346890 }

extractDatabaseId('PRRC_kwDOL4aMSs6Tkzl8')
// → 2475899260
```

### Encoding (Database ID → Node ID) ✨ NEW
```typescript
import { encodeNodeId } from 'gh-please/lib/id-converter'

encodeNodeId({
  type: 'PullRequestReviewComment',
  repositoryId: 797346890,
  databaseId: 2475899260,
})
// → 'PRRC_kwDOL4aMSs6Tkzl8'
```

## Reference
- Greptile Blog: https://www.greptile.com/blog/github-ids
- Spec: specs/001-node-id-decoder/spec.md

Closes #244