### PR TITLE
fix(review): GraphQL schema error in getThreadIdFromComment

### DIFF
--- a/.please/memory/session-summary.md
+++ b/.please/memory/session-summary.md
@@ -1,90 +1,40 @@
-# Session Summary: Node ID Universal Decoder
+# Session Summary
 
-## Feature Description
-GitHub Node ID를 Database ID, Legacy Node ID, New Node ID 형식 간에 자유롭게 변환하는 기능 구현.
-API 호출 없이 로컬에서 직접 디코딩/인코딩하여 빠르고 오프라인에서도 사용 가능.
+## Feature
+- **Name**: Fix GraphQL Schema Error in getThreadIdFromComment
+- **Issue**: #251
+- **Plan**: .please/plans/2026-02-02-fix-review-reply-graphql-error.md
+- **Started**: 2026-02-02T12:50:00Z
 
-## Requirements
-1. **Node ID 디코딩**: New 형식(MessagePack+Base64)과 Legacy 형식(텍스트 Base64) 모두 지원
-2. **Database ID 추출**: Node ID에서 Database ID 직접 추출
-3. **API 없이 동작**: 로컬 디코딩으로 빠르고 오프라인 지원
-4. **기존 코드 통합**: 현재 id-converter.ts에 기능 확장
+## Current Stage
+Stage 1: Setup
 
-## Constraints
-- Bun 런타임 사용 (Node.js 아님)
-- 기존 isNodeId(), isDatabaseId() 함수와 호환
-- MessagePack 디코딩을 위한 의존성 최소화
-
-## Current Phase
-**Phase 2: Codebase Exploration** - 완료
-
-## Codebase Analysis Results
-
-### 현재 ID 변환 구현
-- **파일**: `src/lib/id-converter.ts` (199 lines)
-- **핵심 함수**: `isNodeId()`, `isDatabaseId()`, `toReviewCommentNodeId()`, `toIssueCommentNodeId()`
-- **한계**: REST API 호출로 Node ID 조회 → 추가 API 호출 필요
-
-### Node ID 사용 위치 (GraphQL 필수)
-- `src/lib/github/review-operations.ts` - 리뷰 코멘트 답글/수정
-- `src/lib/github/issue-hierarchy.ts` - 서브이슈, 의존성 관리
-- `src/lib/github/graphql-core.ts` - GraphQL 쿼리 실행
-
-### Database ID 사용 위치 (REST API)
-- `src/lib/github-api.ts` - REST API 엔드포인트 구성
-- `src/types.ts` - 인터페이스 정의
-
-### MessagePack 디코딩 분석 결과
-1. **순수 JS 구현 가능**: ~30줄로 GitHub Node ID 디코딩 가능
-2. **Bun 지원**: `atob()`, `Buffer.from()` 모두 사용 가능
-3. **라이브러리 옵션**: `@msgpack/msgpack` (20KB), `msgpack.js` (2.7KB)
-4. **권장**: 순수 JS 구현 (의존성 없음, GitHub ID에 충분)
-
-### 핵심 파일 (읽어야 할 파일)
-1. src/lib/id-converter.ts - 기존 ID 변환 유틸리티
-2. src/lib/github/graphql-core.ts - GraphQL 코어
-3. src/lib/github/review-operations.ts - 리뷰 작업
-4. test/lib/id-converter.test.ts - 기존 테스트 패턴
-5. docs-dev/adr/0005-id-converter-utility.md - 설계 의사결정
+## Progress
+- [ ] Stage 1: Setup
+- [ ] Stage 2: Implementation
+- [ ] Stage 3: Quality Review
+- [ ] Stage 4: PR Finalization
 
 ## Key Decisions
-- API 없이 로컬 디코딩 방식 선택 (사용자 확인 완료)
-- 순수 JS 구현 선택 (의존성 0, ~50줄 코드)
+- Hybrid approach: Comment ID matching + Thread ID direct input support
+- PR reviewThreads query with comment matching (GitHub recommended)
+- Thread ID direct input for efficiency (skip API calls)
 
-## Architecture Design
+## Files Changed
+(To be updated during implementation)
 
-### 선택된 접근 방식: 순수 JavaScript 구현
+## Branch
+- Name: `251-fixreview-graphql-schema-error-in-getthreadidfromcomment-pullrequestreviewthread-field-doesnt-exist`
+- Linked to: Issue #251
 
-**구조:**
+## Problem Summary
+`gh please pr review reply` command fails with GraphQL schema error:
 ```
-src/lib/
-├── id-converter.ts        # 기존 파일 (확장)
-└── node-id-decoder.ts     # 새 파일 (핵심 디코딩 로직)
-```
-
-**핵심 함수:**
-1. `decodeNodeId(nodeId)` - Node ID 디코딩 (New/Legacy 형식 자동 감지)
-2. `extractDatabaseId(nodeId)` - Database ID만 추출
-3. `getNodeIdType(nodeId)` - 타입 문자열 반환
-
-**MessagePack 디코딩 범위:**
-- fixarray (0x90-0x9f): 배열 헤더
-- positive fixint (0x00-0x7f): 작은 정수
-- uint32 (0xce): 4바이트 정수
-
-**Node ID Prefix 매핑:**
-```typescript
-const PREFIX_MAP = {
-  I_: 'Issue',
-  PR_: 'PullRequest',
-  IC_: 'IssueComment',
-  PRRC_: 'PullRequestReviewComment',
-  PRRT_: 'PullRequestReviewThread',
-  R_: 'Repository',
-  // ... 추가 가능
-}
+Field 'pullRequestReviewThread' doesn't exist on type 'PullRequestReviewComment'
 ```
 
-## Reference
-- Greptile Blog: https://www.greptile.com/blog/github-ids
-- 기존 코드: src/lib/id-converter.ts
+Root cause: `getThreadIdFromComment()` function uses a non-existent GraphQL field.
+
+## Solution Approach
+1. Query PR's reviewThreads and match by comment ID
+2. Add Thread ID (PRRT_...) direct input support for efficiency

--- a/.please/plans/2026-02-02-fix-review-reply-graphql-error.md
+++ b/.please/plans/2026-02-02-fix-review-reply-graphql-error.md
@@ -1,0 +1,302 @@
+# Plan: Fix GraphQL Schema Error in getThreadIdFromComment
+
+## Overview
+- **Source**: GitHub Issue #251
+- **Issue**: #251
+- **Created**: 2026-02-02
+- **Approach**: PR reviewThreads 조회 후 Comment ID 매칭 + Thread ID 직접 입력 지원
+
+## Problem Summary
+
+`gh please pr review reply` 명령이 GraphQL 스키마 오류로 실패:
+```
+❌ Error: GraphQL query failed: gh: Field 'pullRequestReviewThread' doesn't exist on type 'PullRequestReviewComment'
+```
+
+**근본 원인**: `getThreadIdFromComment()` 함수가 존재하지 않는 `PullRequestReviewComment.pullRequestReviewThread` 필드를 사용
+
+## Architecture Decision
+
+### 선택한 접근 방식: 하이브리드 (Comment ID 매칭 + Thread ID 직접 지원)
+
+GitHub GraphQL API 조사 결과, `PullRequestReviewComment`에서 Thread를 직접 가져올 수 있는 필드가 없음.
+GitHub 공식 커뮤니티에서도 `reviewThreads` connection 사용을 권장.
+
+**구현 전략**:
+1. **기존 방식 유지 (Comment ID)**: PR의 `reviewThreads` 조회 후 comment 매칭
+2. **새로운 방식 추가 (Thread ID 직접)**: Thread ID (PRRT_...) 직접 입력 시 바로 사용
+
+### ID 형식별 처리
+
+| 입력 형식 | 예시 | 처리 방식 |
+|-----------|------|-----------|
+| Database ID (숫자) | `2442802556` | reviewThreads 조회 → comment 매칭 |
+| Comment Node ID | `PRRC_kwDOP34z...` | reviewThreads 조회 → comment 매칭 |
+| **Thread Node ID** | `PRRT_kwDOABC...` | **직접 사용 (API 호출 없음)** |
+
+### 대안 비교
+
+| 접근 방식 | 선택 | 이유 |
+|-----------|------|------|
+| PR reviewThreads 매칭 | ✅ 선택 | GitHub 권장, 기존 UX 유지 |
+| Thread ID 직접 입력 | ✅ 추가 | 효율적 (API 호출 생략), 고급 사용자용 |
+| REST API fallback | ❌ | Thread ID 획득 불가 |
+
+### References
+- [GitHub Community Discussion #24666](https://github.com/orgs/community/discussions/24666)
+- [GitHub Community Discussion #24850](https://github.com/orgs/community/discussions/24850)
+
+## Tasks
+
+### Phase 1: ID Detection & Utility
+- [ ] T001 [P] `id-converter.ts`에 Thread ID 감지 함수 추가 - `isThreadNodeId()` (file: src/lib/id-converter.ts)
+- [ ] T002 [P] `id-converter.ts`에 통합 ID 변환 함수 추가 - `resolveThreadId()` (file: src/lib/id-converter.ts)
+- [ ] T003 Unit test 작성 - ID 감지 및 변환 함수 (depends on T001, T002, file: test/lib/id-converter.test.ts)
+
+### Phase 2: Core Fix
+- [ ] T004 `getThreadIdFromComment()` 함수 시그니처 변경 - prNodeId 파라미터 추가 (depends on T001, file: src/lib/github/review-operations.ts)
+- [ ] T005 `getThreadIdFromComment()` 구현 변경 - reviewThreads 조회 후 comment 매칭 (depends on T004, file: src/lib/github/review-operations.ts)
+- [ ] T006 Unit test 작성 - `getThreadIdFromComment()` 함수 (depends on T005, file: test/lib/github/review-operations.test.ts)
+
+### Phase 3: Caller Updates
+- [ ] T007 `createReviewCommentReply()` 수정 - Thread ID 직접 사용 또는 comment에서 조회 (depends on T002, T005, file: src/lib/github/review-operations.ts)
+- [ ] T008 `createReviewReplyCommand()` 수정 - Thread ID 직접 입력 지원 (depends on T007, file: src/commands/pr/review/reply.ts)
+
+### Phase 4: Testing & Validation
+- [ ] T009 Integration test 추가 - reply 명령 E2E 시나리오 (depends on T008, file: test/commands/pr/review/reply.test.ts)
+- [ ] T010 Manual test - 실제 PR에서 reply 명령 테스트 (depends on T009)
+
+## Dependencies
+
+```mermaid
+graph LR
+    T001 --> T003
+    T002 --> T003
+    T001 --> T004
+    T002 --> T007
+    T004 --> T005
+    T005 --> T006
+    T005 --> T007
+    T007 --> T008
+    T008 --> T009
+    T009 --> T010
+```
+
+**Parallel Group 1**: T001, T002 (독립적 - ID 유틸리티)
+**Parallel Group 2**: T003, T004 (T001/T002 완료 후)
+**Sequential Core**: T005 → T006
+**Sequential Caller**: T007 → T008 → T009 → T010
+
+## Key Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/lib/id-converter.ts` | Modify | Thread ID 감지/변환 유틸리티 추가 |
+| `src/lib/github/review-operations.ts` | Modify | 핵심 함수 수정 |
+| `src/commands/pr/review/reply.ts` | Modify | 명령어 호출부 수정, Thread ID 직접 입력 지원 |
+| `test/lib/id-converter.test.ts` | Modify | ID 변환 유틸리티 테스트 |
+| `test/lib/github/review-operations.test.ts` | Create/Modify | Unit tests |
+| `test/commands/pr/review/reply.test.ts` | Create/Modify | Integration tests |
+
+## Implementation Details
+
+### T001: Thread ID 감지 함수 추가 (`id-converter.ts`)
+
+```typescript
+/**
+ * Thread Node ID 형식 감지 (PRRT_...)
+ */
+export function isThreadNodeId(identifier: string): boolean {
+  return /^PRRT_[\w-]+$/.test(identifier)
+}
+```
+
+### T002: 통합 ID 변환 함수 추가 (`id-converter.ts`)
+
+```typescript
+/**
+ * 입력 ID를 Thread ID로 변환
+ * - Thread ID (PRRT_...): 그대로 반환 (API 호출 없음)
+ * - Comment Node ID (PRRC_...): reviewThreads 조회 후 매칭
+ * - Database ID (숫자): Node ID 변환 후 reviewThreads 조회
+ */
+export async function resolveThreadId(
+  identifier: string,
+  prNodeId: string,
+): Promise<string> {
+  // Thread ID면 바로 반환
+  if (isThreadNodeId(identifier)) {
+    return identifier
+  }
+
+  // Comment ID면 thread 찾기
+  return getThreadIdFromComment(identifier, prNodeId)
+}
+```
+
+### T004-T005: `getThreadIdFromComment()` 변경
+
+**Before (현재 - 오류 발생)**:
+```typescript
+export async function getThreadIdFromComment(
+  commentNodeId: string,
+): Promise<string> {
+  const query = `
+    query GetThreadFromComment($commentId: ID!) {
+      node(id: $commentId) {
+        ... on PullRequestReviewComment {
+          pullRequestReviewThread {  // ❌ 존재하지 않는 필드
+            id
+          }
+        }
+      }
+    }
+  `
+  // ...
+}
+```
+
+**After (수정)**:
+```typescript
+export async function getThreadIdFromComment(
+  commentNodeId: string,
+  prNodeId: string,  // 새 파라미터
+): Promise<string> {
+  // 1. PR의 모든 reviewThreads 조회 (최대 100개)
+  const query = `
+    query GetThreadsForComment($prId: ID!) {
+      node(id: $prId) {
+        ... on PullRequest {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 100) {
+                nodes {
+                  id
+                  databaseId
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const data = await executeGraphQL(query, { prId: prNodeId })
+
+  // 2. Comment Node ID 또는 Database ID로 thread 찾기
+  for (const thread of data.node.reviewThreads.nodes) {
+    for (const comment of thread.comments.nodes) {
+      if (comment.id === commentNodeId ||
+          comment.databaseId?.toString() === commentNodeId) {
+        return thread.id
+      }
+    }
+  }
+
+  throw new Error(`Thread not found for comment ${commentNodeId}`)
+}
+```
+
+### T007: `createReviewCommentReply()` 수정
+
+```typescript
+import { isThreadNodeId, resolveThreadId } from '../id-converter'
+
+export async function createReviewCommentReply(
+  identifier: string,  // Comment ID 또는 Thread ID
+  body: string,
+  prNodeId: string,
+): Promise<{ nodeId: string; databaseId: number; url: string }> {
+  // Thread ID면 바로 사용, 아니면 comment에서 조회
+  const threadId = await resolveThreadId(identifier, prNodeId)
+
+  const mutation = `
+    mutation CreateReviewCommentReply($threadId: ID!, $body: String!) {
+      addPullRequestReviewThreadReply(input: {
+        pullRequestReviewThreadId: $threadId
+        body: $body
+      }) {
+        comment {
+          id
+          databaseId
+          url
+        }
+      }
+    }
+  `
+  // ... 나머지 동일
+}
+```
+
+### T008: `createReviewReplyCommand()` 수정
+
+```typescript
+// reply.ts - 명령어 설명 및 argument 업데이트
+command
+  .description('Create a reply to a PR review thread')
+  .argument('<id>', 'Thread ID (PRRT_...), Comment ID (PRRC_...), or Database ID (number)')
+  .option('-b, --body <text>', 'Reply body text')
+  // ...
+
+// action handler 내부
+const prNodeId = await getPrNodeId(prInfo.owner, prInfo.repo, prInfo.number)
+const result = await createReviewCommentReply(identifier, body, prNodeId)
+```
+
+## Verification
+
+### Automated Tests
+- [ ] Unit tests: `getThreadIdFromComment()` 함수 - comment 매칭 로직
+- [ ] Integration tests: `gh please pr review reply` 명령 E2E
+- [ ] 기존 테스트 통과 확인
+
+### Manual Testing
+- [ ] 실제 PR에서 Database ID로 reply 생성
+- [ ] 실제 PR에서 Comment Node ID (PRRC_...)로 reply 생성
+- [ ] **실제 PR에서 Thread Node ID (PRRT_...)로 reply 생성** (NEW)
+- [ ] thread가 100개 초과인 PR에서 테스트 (optional - 페이지네이션 미구현 확인)
+
+### Acceptance Criteria Check
+- [ ] `gh please pr review reply <id>` 명령이 정상 작동
+- [ ] Comment ID (PRRC_...) 입력 지원
+- [ ] Database ID (숫자) 입력 지원
+- [ ] **Thread ID (PRRT_...) 직접 입력 지원** (NEW)
+- [ ] Thread ID 사용 시 API 호출 최소화 확인
+- [ ] 에러 메시지가 명확하고 도움이 됨
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| PR당 100개 thread 제한 | 낮음 | 대부분 PR은 100개 미만, 향후 pagination 추가 가능 |
+| 추가 API 호출로 인한 지연 | 낮음 | 단일 쿼리로 모든 threads/comments 조회 |
+| 기존 테스트 깨짐 | 중간 | 시그니처 변경 시 모든 호출부 업데이트 |
+
+## Notes
+
+- `listReviewThreads()` 함수가 이미 유사한 GraphQL 쿼리를 사용하므로 패턴 재사용 가능
+- i18n 에러 메시지 업데이트 필요할 수 있음 (thread not found 시)
+- 향후 pagination이 필요하면 cursor 기반 pagination 추가 고려
+- **Thread ID 직접 입력 시 API 호출 없이 바로 mutation 실행 가능** - 성능 이점
+
+## CLI Usage Examples
+
+```bash
+# 기존 방식 (Comment ID) - 여전히 작동
+gh please pr review reply 2442802556 -b "Fixed!"                  # Database ID
+gh please pr review reply PRRC_kwDOP34zbs6ShH0J -b "Fixed!"       # Comment Node ID
+
+# 새로운 방식 (Thread ID) - 직접 입력
+gh please pr review thread list 123                               # Thread ID 조회
+gh please pr review reply PRRT_kwDOABC123xyz -b "Fixed!"          # Thread Node ID 직접 사용
+```
+
+## Review Status
+- **Reviewed**: 2026-02-02
+- **Result**: APPROVED
+- **User Approved**: Yes
+- **Issue Comment**: https://github.com/pleaseai/gh-please/issues/251#issuecomment-3832751980
+- **Command Structure Decision**: `review reply` 유지 (기존 호환성, 간결함)
+- **Reviewer Notes**: Plan is technically sound and addresses the core problem correctly

--- a/.please/tasklist.json
+++ b/.please/tasklist.json
@@ -1,0 +1,121 @@
+{
+  "feature": "Fix GraphQL Schema Error in getThreadIdFromComment",
+  "issue_number": 251,
+  "plan_path": ".please/plans/2026-02-02-fix-review-reply-graphql-error.md",
+  "spec": null,
+  "stage": 1,
+  "created_at": "2026-02-02T12:50:00Z",
+  "tasks": [
+    {
+      "id": "T001",
+      "title": "id-converter.ts에 Thread ID 감지 함수 추가 - isThreadNodeId()",
+      "phase": 1,
+      "status": "pending",
+      "parallel": true,
+      "dependencies": [],
+      "files_affected": ["src/lib/id-converter.ts"]
+    },
+    {
+      "id": "T002",
+      "title": "id-converter.ts에 통합 ID 변환 함수 추가 - resolveThreadId()",
+      "phase": 1,
+      "status": "pending",
+      "parallel": true,
+      "dependencies": [],
+      "files_affected": ["src/lib/id-converter.ts"]
+    },
+    {
+      "id": "T003",
+      "title": "Unit test 작성 - ID 감지 및 변환 함수",
+      "phase": 1,
+      "status": "pending",
+      "parallel": false,
+      "dependencies": ["T001", "T002"],
+      "files_affected": ["test/lib/id-converter.test.ts"]
+    },
+    {
+      "id": "T004",
+      "title": "getThreadIdFromComment() 함수 시그니처 변경 - prNodeId 파라미터 추가",
+      "phase": 2,
+      "status": "pending",
+      "parallel": false,
+      "dependencies": ["T001"],
+      "files_affected": ["src/lib/github/review-operations.ts"]
+    },
+    {
+      "id": "T005",
+      "title": "getThreadIdFromComment() 구현 변경 - reviewThreads 조회 후 comment 매칭",
+      "phase": 2,
+      "status": "pending",
+      "parallel": false,
+      "dependencies": ["T004"],
+      "files_affected": ["src/lib/github/review-operations.ts"]
+    },
+    {
+      "id": "T006",
+      "title": "Unit test 작성 - getThreadIdFromComment() 함수",
+      "phase": 2,
+      "status": "pending",
+      "parallel": false,
+      "dependencies": ["T005"],
+      "files_affected": ["test/lib/github/review-operations.test.ts"]
+    },
+    {
+      "id": "T007",
+      "title": "createReviewCommentReply() 수정 - Thread ID 직접 사용 또는 comment에서 조회",
+      "phase": 3,
+      "status": "pending",
+      "parallel": false,
+      "dependencies": ["T002", "T005"],
+      "files_affected": ["src/lib/github/review-operations.ts"]
+    },
+    {
+      "id": "T008",
+      "title": "createReviewReplyCommand() 수정 - Thread ID 직접 입력 지원",
+      "phase": 3,
+      "status": "pending",
+      "parallel": false,
+      "dependencies": ["T007"],
+      "files_affected": ["src/commands/pr/review/reply.ts"]
+    },
+    {
+      "id": "T009",
+      "title": "Integration test 추가 - reply 명령 E2E 시나리오",
+      "phase": 4,
+      "status": "pending",
+      "parallel": false,
+      "dependencies": ["T008"],
+      "files_affected": ["test/commands/pr/review/reply.test.ts"]
+    },
+    {
+      "id": "T010",
+      "title": "Manual test - 실제 PR에서 reply 명령 테스트",
+      "phase": 4,
+      "status": "pending",
+      "parallel": false,
+      "dependencies": ["T009"],
+      "files_affected": []
+    }
+  ],
+  "verification": {
+    "automated_tests": [
+      "Unit tests: getThreadIdFromComment() 함수 - comment 매칭 로직",
+      "Integration tests: gh please pr review reply 명령 E2E",
+      "기존 테스트 통과 확인"
+    ],
+    "manual_tests": [
+      "실제 PR에서 Database ID로 reply 생성",
+      "실제 PR에서 Comment Node ID (PRRC_...)로 reply 생성",
+      "실제 PR에서 Thread Node ID (PRRT_...)로 reply 생성",
+      "thread가 100개 초과인 PR에서 테스트 (optional)"
+    ],
+    "acceptance_criteria": [
+      "gh please pr review reply <id> 명령이 정상 작동",
+      "Comment ID (PRRC_...) 입력 지원",
+      "Database ID (숫자) 입력 지원",
+      "Thread ID (PRRT_...) 직접 입력 지원",
+      "Thread ID 사용 시 API 호출 최소화 확인",
+      "에러 메시지가 명확하고 도움이 됨"
+    ]
+  }
+}

--- a/src/commands/pr/review/reply.ts
+++ b/src/commands/pr/review/reply.ts
@@ -1,30 +1,36 @@
 import { Command } from 'commander'
-import { createReviewCommentReply } from '../../../lib/github'
+import { createReviewCommentReply, getPrNodeId } from '../../../lib/github'
 import { getCurrentPrInfo, getRepoInfo } from '../../../lib/github-api'
 import { detectSystemLanguage, getPrMessages } from '../../../lib/i18n'
-import { toReviewCommentNodeId, validateCommentIdentifier } from '../../../lib/id-converter'
+import { isDatabaseId, isNodeId, isThreadNodeId } from '../../../lib/id-converter'
 import { validateReplyBody } from '../../../lib/validation'
 
 /**
- * Creates a command to reply to PR review comments
+ * Creates a command to reply to PR review threads
  * @returns Command object configured for creating review replies
  */
 export function createReviewReplyCommand(): Command {
   const command = new Command('reply')
 
   command
-    .description('Create a reply to a PR review comment')
-    .argument('<comment-id>', 'Database ID (number) or Node ID (PRRC_...) of the review comment')
+    .description('Create a reply to a PR review thread')
+    .argument('<id>', 'Thread ID (PRRT_...), Comment ID (PRRC_...), or Database ID (number)')
     .option('-b, --body <text>', 'Reply body text')
     .option('-R, --repo <owner/repo>', 'Repository in owner/repo format (required if not in PR context)')
     .option('--pr <number>', 'PR number (required with --repo)')
-    .action(async (commentIdStr: string, options: { body?: string, repo?: string, pr?: string }) => {
+    .action(async (idStr: string, options: { body?: string, repo?: string, pr?: string }) => {
       const lang = detectSystemLanguage()
       const msg = getPrMessages(lang)
 
       try {
-        // Validate comment identifier (Database ID or Node ID)
-        const commentIdentifier = validateCommentIdentifier(commentIdStr)
+        // Validate identifier format
+        const identifier = idStr.trim()
+        if (!isThreadNodeId(identifier) && !isNodeId(identifier) && !isDatabaseId(identifier)) {
+          throw new Error(
+            `Invalid identifier: "${identifier}". `
+            + 'Expected Thread ID (PRRT_...), Comment ID (PRRC_...), or Database ID (positive integer)',
+          )
+        }
 
         let body = options.body
 
@@ -67,26 +73,27 @@ export function createReviewReplyCommand(): Command {
           prInfo = await getCurrentPrInfo()
         }
 
-        // Convert comment identifier to Node ID (supports both Database ID and Node ID)
-        console.log(`🔄 Converting comment identifier to Node ID...`)
-        const commentNodeId = await toReviewCommentNodeId(
-          commentIdentifier,
-          prInfo.owner,
-          prInfo.repo,
-          prInfo.number,
-        )
+        // Get PR Node ID for the createReviewCommentReply function
+        const prNodeId = await getPrNodeId(prInfo.owner, prInfo.repo, prInfo.number)
 
-        // For display purposes, show original identifier
-        const displayId = Number.parseInt(commentIdentifier, 10)
-        if (!Number.isNaN(displayId)) {
-          console.log(msg.creatingReply(displayId, prInfo.number))
+        // Show progress based on identifier type
+        if (isThreadNodeId(identifier)) {
+          console.log(`🔄 Creating reply to thread ${identifier} on PR #${prInfo.number}...`)
         }
         else {
-          console.log(`🔄 Creating reply to comment ${commentIdentifier} on PR #${prInfo.number}...`)
+          const displayId = Number.parseInt(identifier, 10)
+          if (!Number.isNaN(displayId)) {
+            console.log(msg.creatingReply(displayId, prInfo.number))
+          }
+          else {
+            console.log(`🔄 Creating reply to comment ${identifier} on PR #${prInfo.number}...`)
+          }
         }
 
-        // Create reply using GraphQL (supports all comment types including general comments)
-        const result = await createReviewCommentReply(commentNodeId, body)
+        // Create reply using GraphQL
+        // - Thread ID (PRRT_...): used directly, no additional API call
+        // - Comment ID or Database ID: finds thread via reviewThreads query
+        const result = await createReviewCommentReply(identifier, body, prNodeId)
 
         console.log(`✅ Reply created successfully!`)
         console.log(`   Comment ID: ${result.databaseId}`)

--- a/src/lib/github/review-operations.ts
+++ b/src/lib/github/review-operations.ts
@@ -91,62 +91,112 @@ export async function listReviewThreads(
 }
 
 /**
- * Get the Thread ID for a review comment
+ * Get the Thread ID for a review comment by searching PR's reviewThreads
  *
- * @param commentNodeId - Node ID of the review comment (PRRC_...)
+ * GitHub GraphQL API does not provide a direct field to get thread from comment.
+ * This function queries all reviewThreads on the PR and finds the thread
+ * that contains the target comment.
+ *
+ * @param commentIdentifier - Node ID (PRRC_...) or Database ID of the review comment
+ * @param prNodeId - Node ID of the pull request
  * @returns Thread Node ID (PRRT_...)
  * @throws Error if the comment or thread is not found
+ * @see https://github.com/orgs/community/discussions/24666
  */
 export async function getThreadIdFromComment(
-  commentNodeId: string,
+  commentIdentifier: string,
+  prNodeId: string,
 ): Promise<string> {
+  // Query all reviewThreads with their comments
   const query = `
-    query GetThreadFromComment($commentId: ID!) {
-      node(id: $commentId) {
-        ... on PullRequestReviewComment {
-          pullRequestReviewThread {
-            id
+    query GetThreadsForComment($prId: ID!) {
+      node(id: $prId) {
+        ... on PullRequest {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 100) {
+                nodes {
+                  id
+                  databaseId
+                }
+              }
+            }
           }
         }
       }
     }
   `
 
-  const data = await executeGraphQL(query, { commentId: commentNodeId }, undefined, 'GetThreadFromComment')
+  const data = await executeGraphQL(query, { prId: prNodeId }, undefined, 'GetThreadsForComment')
 
-  if (!data.node?.pullRequestReviewThread?.id) {
+  if (!data.node?.reviewThreads?.nodes) {
     throw new Error(
-      `Thread not found for review comment ${commentNodeId}.\n`
-      + `Possible reasons:\n`
-      + `  • The comment may have been deleted\n`
-      + `  • The comment ID may be incorrect (use 'gh please pr review thread list <pr>' to see valid IDs)\n`
-      + `  • You may lack permissions to view this PR\n`
-      + `\n`
-      + `Please verify the comment ID and try again.`,
+      `Failed to fetch review threads from PR.\n`
+      + `Please verify the PR Node ID and try again.`,
     )
   }
 
-  return data.node.pullRequestReviewThread.id
+  // Search for the comment in all threads
+  for (const thread of data.node.reviewThreads.nodes) {
+    for (const comment of thread.comments?.nodes || []) {
+      // Match by Node ID or Database ID
+      if (
+        comment.id === commentIdentifier
+        || comment.databaseId?.toString() === commentIdentifier
+      ) {
+        return thread.id
+      }
+    }
+  }
+
+  throw new Error(
+    `Thread not found for review comment ${commentIdentifier}.\n`
+    + `Possible reasons:\n`
+    + `  • The comment may have been deleted\n`
+    + `  • The comment ID may be incorrect (use 'gh please pr review thread list <pr>' to see valid IDs)\n`
+    + `  • The PR may have more than 100 review threads (pagination not yet supported)\n`
+    + `  • You may lack permissions to view this PR\n`
+    + `\n`
+    + `Please verify the comment ID and try again.`,
+  )
 }
 
 /**
- * Create a reply to a PR review comment using Node ID
+ * Create a reply to a PR review thread
  *
- * @param commentNodeId - Node ID of the comment to reply to (PRRC_...)
+ * Supports multiple identifier formats:
+ * - Thread Node ID (PRRT_...): Used directly, no additional API call
+ * - Comment Node ID (PRRC_...): Finds thread via reviewThreads query
+ * - Database ID (number): Finds thread via reviewThreads query
+ *
+ * @param identifier - Thread ID (PRRT_...), Comment ID (PRRC_...), or Database ID
  * @param body - Reply body text
+ * @param prNodeId - Node ID of the pull request
  * @returns Created reply information
  * @throws Error if the mutation fails
  */
 export async function createReviewCommentReply(
-  commentNodeId: string,
+  identifier: string,
   body: string,
+  prNodeId: string,
 ): Promise<{
   nodeId: string
   databaseId: number
   url: string
 }> {
-  // Get the thread ID from the comment
-  const threadId = await getThreadIdFromComment(commentNodeId)
+  // Determine the thread ID based on identifier format
+  let threadId: string
+
+  // Check if identifier is already a Thread Node ID (PRRT_...)
+  if (/^PRRT_[\w-]+$/.test(identifier)) {
+    // Use Thread ID directly - no API call needed
+    threadId = identifier
+  }
+  else {
+    // Get the thread ID from comment (by searching reviewThreads)
+    threadId = await getThreadIdFromComment(identifier, prNodeId)
+  }
 
   const mutation = `
     mutation CreateReviewCommentReply($threadId: ID!, $body: String!) {

--- a/src/lib/github/review-operations.ts
+++ b/src/lib/github/review-operations.ts
@@ -156,6 +156,7 @@ export async function getThreadIdFromComment(
     + `  • The comment may have been deleted\n`
     + `  • The comment ID may be incorrect (use 'gh please pr review thread list <pr>' to see valid IDs)\n`
     + `  • The PR may have more than 100 review threads (pagination not yet supported)\n`
+    + `  • The thread may have more than 100 comments (pagination not yet supported)\n`
     + `  • You may lack permissions to view this PR\n`
     + `\n`
     + `Please verify the comment ID and try again.`,

--- a/src/lib/id-converter.ts
+++ b/src/lib/id-converter.ts
@@ -43,6 +43,28 @@ export function isNodeId(identifier: string): boolean {
 }
 
 /**
+ * Detect if identifier is a Thread Node ID (PRRT_...)
+ * Thread IDs are used for PR review threads
+ *
+ * @param identifier - String to check
+ * @returns True if identifier is a Thread Node ID
+ */
+export function isThreadNodeId(identifier: string): boolean {
+  return /^PRRT_[\w-]+$/.test(identifier)
+}
+
+/**
+ * Detect if identifier is a Comment Node ID (PRRC_... or IC_...)
+ * Comment IDs are used for PR review comments or issue comments
+ *
+ * @param identifier - String to check
+ * @returns True if identifier is a Comment Node ID
+ */
+export function isCommentNodeId(identifier: string): boolean {
+  return /^(?:PRRC|IC)_[\w-]+$/.test(identifier)
+}
+
+/**
  * Detect if identifier is a Database ID (positive integer)
  *
  * @param identifier - String to check

--- a/test/fixtures/github-responses.ts
+++ b/test/fixtures/github-responses.ts
@@ -311,7 +311,7 @@ export function createResolveThreadResponse(threadId: string) {
 /**
  * GraphQL Response: List Review Threads
  */
-export function createListReviewThreadsResponse(threads: Array<{ id: string, isResolved: boolean, path: string, line: number | null, comments?: Array<{ id: string }> }>) {
+export function createListReviewThreadsResponse(threads: Array<{ id: string, isResolved: boolean, path: string, line: number | null, comments?: Array<{ id: string, databaseId?: number }> }>) {
   return {
     data: {
       node: {
@@ -323,6 +323,26 @@ export function createListReviewThreadsResponse(threads: Array<{ id: string, isR
             line: thread.line,
             comments: {
               nodes: thread.comments || [],
+            },
+          })),
+        },
+      },
+    },
+  }
+}
+
+/**
+ * GraphQL Response: Get Threads For Comment (used for finding thread by comment ID)
+ */
+export function createGetThreadsForCommentResponse(threads: Array<{ id: string, comments: Array<{ id: string, databaseId: number }> }>) {
+  return {
+    data: {
+      node: {
+        reviewThreads: {
+          nodes: threads.map(thread => ({
+            id: thread.id,
+            comments: {
+              nodes: thread.comments,
             },
           })),
         },

--- a/test/integration/cli/pr-commands.test.ts
+++ b/test/integration/cli/pr-commands.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, test } from 'bun:test'
 import {
   createGetPrNodeIdResponse,
   createGetReviewCommentResponse,
+  createGetThreadsForCommentResponse,
   createListReviewThreadsResponse,
   createResolveThreadResponse,
   createReviewReplyResponse,
@@ -110,9 +111,34 @@ describe('PR Commands - CLI Integration', () => {
           exitCode: 0,
         },
       },
-      // Mock list review threads (GraphQL)
+      // Mock get thread ID from comment (GraphQL - GetThreadsForComment)
+      // IMPORTANT: This must come BEFORE the list review threads mock because
+      // both use reviewThreads query, but this one uses operationName=GetThreadsForComment
       {
-        args: /api graphql -f query=.*reviewThreads.*first.*-F prId=/,
+        args: /api graphql.*operationName=GetThreadsForComment/,
+        response: {
+          stdout: JSON.stringify(
+            createGetThreadsForCommentResponse([
+              {
+                id: mockReviewThread.id,
+                comments: [
+                  { id: mockReviewComment.nodeId, databaseId: mockReviewComment.id },
+                ],
+              },
+              {
+                id: 'PRRT_kwDOABCDEF67890',
+                comments: [
+                  { id: 'PRRC_kwDOAnotherComment', databaseId: 111222333 },
+                ],
+              },
+            ]),
+          ),
+          exitCode: 0,
+        },
+      },
+      // Mock list review threads (GraphQL - ListReviewThreads)
+      {
+        args: /api graphql.*operationName=ListReviewThreads/,
         response: {
           stdout: JSON.stringify(
             createListReviewThreadsResponse([
@@ -121,7 +147,7 @@ describe('PR Commands - CLI Integration', () => {
                 isResolved: false,
                 path: mockReviewThread.path,
                 line: mockReviewThread.line,
-                comments: [{ id: mockReviewComment.nodeId }],
+                comments: [{ id: mockReviewComment.nodeId, databaseId: mockReviewComment.id }],
               },
               {
                 id: 'PRRT_kwDOABCDEF67890',
@@ -141,22 +167,6 @@ describe('PR Commands - CLI Integration', () => {
           stdout: JSON.stringify(
             createResolveThreadResponse(mockReviewThread.id),
           ),
-          exitCode: 0,
-        },
-      },
-      // Mock get thread ID from comment (GraphQL - Optimized single query)
-      {
-        args: /api graphql.*-F commentId=PRRC_/,
-        response: {
-          stdout: JSON.stringify({
-            data: {
-              node: {
-                pullRequestReviewThread: {
-                  id: mockReviewThread.id,
-                },
-              },
-            },
-          }),
           exitCode: 0,
         },
       },

--- a/test/lib/github-graphql.test.ts
+++ b/test/lib/github-graphql.test.ts
@@ -213,9 +213,10 @@ describe('github-graphql', () => {
       expect(typeof getThreadIdFromComment).toBe('function')
     })
 
-    test('should accept commentNodeId parameter', () => {
+    test('should accept commentIdentifier and prNodeId parameters', () => {
       const func = getThreadIdFromComment.toString()
-      expect(func).toContain('commentNodeId')
+      expect(func).toContain('commentIdentifier')
+      expect(func).toContain('prNodeId')
     })
 
     test('should be async function', () => {
@@ -223,11 +224,11 @@ describe('github-graphql', () => {
       expect(func).toContain('async')
     })
 
-    test('should use GraphQL query to fetch thread information', () => {
+    test('should use GraphQL query to fetch reviewThreads from PR', () => {
       const func = getThreadIdFromComment.toString()
       expect(func).toContain('query')
-      expect(func).toContain('pullRequestReviewThread')
-      expect(func).toContain('PullRequestReviewComment')
+      expect(func).toContain('reviewThreads')
+      expect(func).toContain('PullRequest')
     })
 
     test('should return thread ID string', () => {
@@ -235,21 +236,22 @@ describe('github-graphql', () => {
       expect(typeof getThreadIdFromComment).toBe('function')
     })
 
-    // Behavioral tests for optimized single-query logic
-    describe('single-query behavior', () => {
+    // Behavioral tests for reviewThreads-based lookup
+    describe('reviewThreads-based lookup', () => {
       // Note: These tests verify the implementation without mocking executeGraphQL
       // since it's a module-level import. Integration tests cover actual execution.
 
-      test('should query pullRequestReviewThread field directly', () => {
+      test('should query reviewThreads with comments', () => {
         const func = getThreadIdFromComment.toString()
-        // Verify direct query for pullRequestReviewThread
-        expect(func).toContain('pullRequestReviewThread')
-        expect(func).toContain('PullRequestReviewComment')
+        // Verify query fetches reviewThreads with nested comments
+        expect(func).toContain('reviewThreads')
+        expect(func).toContain('comments')
+        expect(func).toContain('databaseId')
       })
 
       test('should use single GraphQL query', () => {
         const func = getThreadIdFromComment.toString()
-        // Verify only one executeGraphQL call (optimized)
+        // Verify only one executeGraphQL call
         const queryMatches = func.match(/executeGraphQL/g)
         expect(queryMatches?.length).toBe(1)
       })
@@ -268,10 +270,11 @@ describe('github-graphql', () => {
       expect(typeof createReviewCommentReply).toBe('function')
     })
 
-    test('should accept commentNodeId and body parameters', () => {
+    test('should accept identifier, body, and prNodeId parameters', () => {
       const func = createReviewCommentReply.toString()
-      expect(func).toContain('commentNodeId')
+      expect(func).toContain('identifier')
       expect(func).toContain('body')
+      expect(func).toContain('prNodeId')
     })
 
     test('should be async function', () => {
@@ -279,7 +282,12 @@ describe('github-graphql', () => {
       expect(func).toContain('async')
     })
 
-    test('should call getThreadIdFromComment', () => {
+    test('should support Thread ID (PRRT_) direct usage', () => {
+      const func = createReviewCommentReply.toString()
+      expect(func).toContain('PRRT_')
+    })
+
+    test('should call getThreadIdFromComment for non-thread IDs', () => {
       const func = createReviewCommentReply.toString()
       expect(func).toContain('getThreadIdFromComment')
     })

--- a/test/lib/id-converter.test.ts
+++ b/test/lib/id-converter.test.ts
@@ -5,10 +5,12 @@ import {
   extractDatabaseId,
   getNodeIdPrefix,
   getNodeIdType,
+  isCommentNodeId,
   isDatabaseId,
   isLegacyNodeId,
   isNewNodeId,
   isNodeId,
+  isThreadNodeId,
   toIssueCommentNodeId,
   toReviewCommentNodeId,
   validateCommentIdentifier,
@@ -204,6 +206,48 @@ describe('id-converter', () => {
           expect(error.message.length).toBeGreaterThan(0)
         }
       }
+    })
+  })
+
+  describe('isThreadNodeId', () => {
+    test('should detect PR review thread Node ID', () => {
+      expect(isThreadNodeId('PRRT_kwDOABC123xyz')).toBe(true)
+      expect(isThreadNodeId('PRRT_kwDOL4aMSs6Aw-LK')).toBe(true)
+    })
+
+    test('should reject PR review comment Node ID', () => {
+      expect(isThreadNodeId('PRRC_kwDOP34zbs6ShH0J')).toBe(false)
+    })
+
+    test('should reject issue comment Node ID', () => {
+      expect(isThreadNodeId('IC_kwDOABC123')).toBe(false)
+    })
+
+    test('should reject database ID (number)', () => {
+      expect(isThreadNodeId('2458156297')).toBe(false)
+    })
+
+    test('should reject invalid format', () => {
+      expect(isThreadNodeId('invalid-id')).toBe(false)
+      expect(isThreadNodeId('')).toBe(false)
+    })
+  })
+
+  describe('isCommentNodeId', () => {
+    test('should detect PR review comment Node ID', () => {
+      expect(isCommentNodeId('PRRC_kwDOP34zbs6ShH0J')).toBe(true)
+    })
+
+    test('should detect issue comment Node ID', () => {
+      expect(isCommentNodeId('IC_kwDOABC123')).toBe(true)
+    })
+
+    test('should reject PR review thread Node ID', () => {
+      expect(isCommentNodeId('PRRT_kwDOABC123xyz')).toBe(false)
+    })
+
+    test('should reject database ID (number)', () => {
+      expect(isCommentNodeId('2458156297')).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary

Fix `gh please pr review reply` command failing with GraphQL schema error when replying to review comments.

## Problem

The `getThreadIdFromComment()` function in `src/lib/github-graphql.ts` attempts to query a non-existent `pullRequestReviewThread` field on the PR query, causing GraphQL schema validation errors.

**Error:**
```
❌ Error: GraphQL query failed: gh: Field 'pullRequestReviewThread' doesn't exist on type 'PullRequestReviewComment'
```

## Solution

- Replace the non-existent field query with PR's `reviewThreads` connection
- Query threads to find the one containing the target comment ID
- Support direct Thread Node ID input as an optimization to skip the lookup
- Update function signature to accept PR Node ID as required parameter
- Maintain backward compatibility with Database ID and Node ID comment inputs

## Changes

- Updated `getThreadIdFromComment()` to query `reviewThreads` connection
- Added support for direct Thread Node ID input
- Enhanced ID detection and conversion logic
- Maintains backward compatibility with comment ID input
- Fixes GraphQL schema validation

## Test Plan

- [ ] Test `gh please pr review reply <comment-id> -b "text"` with Database ID
- [ ] Test `gh please pr review reply <node-id> -b "text"` with Node ID  
- [ ] Test `gh please pr review reply <thread-node-id> -b "text"` with Thread ID
- [ ] Verify all GraphQL queries pass schema validation
- [ ] Run integration tests for review commands

## Related Issues

Closes #251