### PR TITLE
feat(develop): use cloned repo gitDir for worktree creation

### DIFF
--- a/src/commands/issue/develop.ts
+++ b/src/commands/issue/develop.ts
@@ -2,7 +2,7 @@ import type { DevelopOptions } from '../../types'
 import * as fs from 'node:fs'
 import { confirm, select } from '@clack/prompts'
 import { Command } from 'commander'
-import { createWorktree, fetchBranch, getAllLinkedBranches, startDevelopWorkflow } from '../../lib/git-workflow'
+import { createWorktree, createWorktreeFromRepo, fetchBranch, getAllLinkedBranches, startDevelopWorkflow } from '../../lib/git-workflow'
 import { detectSystemLanguage, getIssueMessages } from '../../lib/i18n'
 import { cloneBareRepo, findBareRepo, resolveRepository } from '../../lib/repo-manager'
 
@@ -39,25 +39,10 @@ export function createDevelopCommand(): Command {
           // Resolve repository
           console.log(msg.developCheckingRepo)
           const repoInfo = await resolveRepository(options.repo)
-          let bareRepoPath = await findBareRepo(repoInfo.owner, repoInfo.repo)
-
-          if (!bareRepoPath) {
-            // Prompt to clone
-            const shouldClone = await confirm({
-              message: msg.developPromptClone(repoInfo.owner, repoInfo.repo),
-            })
-
-            if (!shouldClone) {
-              console.log('Cancelled.')
-              process.exit(0)
-            }
-
-            console.log(msg.developCloning(repoInfo.owner, repoInfo.repo))
-            bareRepoPath = await cloneBareRepo(repoInfo.owner, repoInfo.repo)
-          }
 
           // Check for existing linked branches
-          const existingBranches = await getAllLinkedBranches(issueNumber, options.repo)
+          const repoString = options.repo || `${repoInfo.owner}/${repoInfo.repo}`
+          const existingBranches = await getAllLinkedBranches(issueNumber, repoString)
 
           let branch: string
           if (existingBranches.length === 0) {
@@ -100,7 +85,7 @@ export function createDevelopCommand(): Command {
             branch = selectedOption === '__new__' ? await startDevelopWorkflow(issueNumber, options) : selectedOption
           }
 
-          // Prepare worktree path
+          // Prepare worktree path (centralized location)
           const worktreePath = `~/.please/worktrees/${repoInfo.repo}/${branch}`
           const expandedPath = worktreePath.replace(/^~/, process.env.HOME || '')
 
@@ -109,12 +94,42 @@ export function createDevelopCommand(): Command {
             console.log(`✅ Worktree already exists!`)
             console.log(`cd ${expandedPath}`)
           }
+          else if (repoInfo.gitDir && !options.repo) {
+            // Case 1: Inside a cloned repo without --repo flag
+            // Use the current repo's gitDir for worktree (proper remote tracking)
+            console.log(`📥 Fetching branch ${branch}...`)
+
+            // Create worktree from current repo
+            console.log(msg.developCreateWorktree(worktreePath))
+            await createWorktreeFromRepo(repoInfo.gitDir, branch, worktreePath)
+
+            console.log(msg.developWorktreeReady(expandedPath))
+            console.log(`cd ${expandedPath}`)
+          }
           else {
+            // Case 2: Outside repo or --repo specified - use bare repo mode
+            let bareRepoPath = await findBareRepo(repoInfo.owner, repoInfo.repo)
+
+            if (!bareRepoPath) {
+              // Prompt to clone
+              const shouldClone = await confirm({
+                message: msg.developPromptClone(repoInfo.owner, repoInfo.repo),
+              })
+
+              if (!shouldClone) {
+                console.log('Cancelled.')
+                process.exit(0)
+              }
+
+              console.log(msg.developCloning(repoInfo.owner, repoInfo.repo))
+              bareRepoPath = await cloneBareRepo(repoInfo.owner, repoInfo.repo)
+            }
+
             // Fetch branch into bare repo before creating worktree
             console.log(`📥 Fetching branch ${branch}...`)
             await fetchBranch(bareRepoPath, branch)
 
-            // Create worktree
+            // Create worktree from bare repo
             console.log(msg.developCreateWorktree(worktreePath))
             await createWorktree(bareRepoPath, branch, worktreePath)
 

--- a/src/lib/gh-command.ts
+++ b/src/lib/gh-command.ts
@@ -1,0 +1,6 @@
+/**
+ * Get the gh command path from environment variable or use default
+ */
+export function getGhCommand(): string {
+  return process.env.GH_PATH || 'gh'
+}

--- a/src/lib/git-exec.ts
+++ b/src/lib/git-exec.ts
@@ -1,0 +1,34 @@
+/**
+ * Result of a git command execution
+ */
+export interface GitResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Execute a git command and return the result
+ */
+export async function runGitCommand(args: string[]): Promise<GitResult> {
+  const proc = Bun.spawn(args, {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+
+  return { exitCode, stdout, stderr }
+}
+
+/**
+ * Log a warning with a follow-up message
+ */
+export function warnWithFollowup(message: string, followup: string): void {
+  console.warn(`⚠️ Warning: ${message}`)
+  console.warn(`   ${followup}`)
+}

--- a/src/lib/git-workflow-worktree.ts
+++ b/src/lib/git-workflow-worktree.ts
@@ -49,22 +49,45 @@ export async function createWorktreeFromRepo(
 ): Promise<void> {
   const expandedPath = await ensureParentDirectory(targetPath)
 
-  // First, fetch the branch to ensure we have the latest
-  const fetchResult = await runGitCommand(['git', '--git-dir', gitDir, 'fetch', 'origin', branch])
+  // Step 1: Fetch the branch with explicit refspec to update remote-tracking ref
+  // Using refspec ensures refs/remotes/origin/{branch} is updated
+  const fetchResult = await runGitCommand([
+    'git',
+    '--git-dir',
+    gitDir,
+    'fetch',
+    'origin',
+    `${branch}:refs/remotes/origin/${branch}`,
+  ])
   if (fetchResult.exitCode !== 0) {
-    warnWithFollowup(
-      `Could not fetch latest changes from remote: ${fetchResult.stderr.trim() || 'unknown error'}`,
-      'Proceeding with local branch state. Your worktree may not have the latest remote changes.',
-    )
+    // Check if it's a "couldn't find remote ref" error (local-only branch)
+    if (!fetchResult.stderr.includes('couldn\'t find remote ref')) {
+      warnWithFollowup(
+        `Could not fetch latest changes from remote: ${fetchResult.stderr.trim() || 'unknown error'}`,
+        'Proceeding with local branch state. Your worktree may not have the latest remote changes.',
+      )
+    }
   }
 
-  // Check if branch exists locally
+  // Step 2: Update local branch to match remote (if fetch succeeded)
+  // This ensures the worktree uses the latest code, not stale local branch
+  // Using -f flag: creates branch if not exists, updates if exists
+  await runGitCommand([
+    'git',
+    '--git-dir',
+    gitDir,
+    'branch',
+    '-f',
+    branch,
+    `refs/remotes/origin/${branch}`,
+  ])
+  // Ignore update errors - origin/branch might not exist for local-only branches
+
+  // Check if branch exists locally (for worktree add command selection)
   const checkResult = await runGitCommand(['git', '--git-dir', gitDir, 'rev-parse', '--verify', `refs/heads/${branch}`])
   const branchExists = checkResult.exitCode === 0
 
   // Create worktree with the branch
-  // If branch exists locally, just use it
-  // If not, create it tracking origin/{branch}
   const worktreeArgs = branchExists
     ? ['git', '--git-dir', gitDir, 'worktree', 'add', expandedPath, branch]
     : ['git', '--git-dir', gitDir, 'worktree', 'add', '-b', branch, expandedPath, `origin/${branch}`]

--- a/src/lib/git-workflow-worktree.ts
+++ b/src/lib/git-workflow-worktree.ts
@@ -1,0 +1,197 @@
+import type { WorktreeInfo } from '../types'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+/**
+ * Ensure parent directory exists for a target path
+ * @param targetPath - Path to the target (may include ~)
+ * @returns The expanded absolute path
+ */
+async function ensureParentDirectory(targetPath: string): Promise<string> {
+  const expandedPath = targetPath.replace(/^~/, process.env.HOME || '')
+  const parentDir = path.dirname(expandedPath)
+  try {
+    await fs.promises.mkdir(parentDir, { recursive: true })
+  }
+  catch (error) {
+    throw new Error(`Failed to create directory ${parentDir}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  return expandedPath
+}
+
+/**
+ * Create worktree at target path using git worktree add (from bare repo)
+ */
+export async function createWorktree(
+  bareRepoPath: string,
+  branch: string,
+  targetPath: string,
+): Promise<void> {
+  const expandedPath = await ensureParentDirectory(targetPath)
+
+  const proc = Bun.spawn(
+    ['git', '-C', bareRepoPath, 'worktree', 'add', expandedPath, branch],
+    {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  )
+
+  const exitCode = await proc.exited
+
+  if (exitCode !== 0) {
+    const error = await new Response(proc.stderr).text()
+    throw new Error(`Failed to create worktree: ${error.trim()}`)
+  }
+}
+
+/**
+ * Create worktree from a cloned repository (non-bare)
+ * Uses the existing repo's git directory to create worktree
+ * This ensures proper remote tracking for fetch operations in the worktree
+ */
+export async function createWorktreeFromRepo(
+  gitDir: string,
+  branch: string,
+  targetPath: string,
+): Promise<void> {
+  const expandedPath = await ensureParentDirectory(targetPath)
+
+  // First, fetch the branch to ensure we have the latest
+  const fetchProc = Bun.spawn(
+    ['git', '--git-dir', gitDir, 'fetch', 'origin', branch],
+    {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  )
+
+  const fetchExitCode = await fetchProc.exited
+  // Log warning if fetch fails - branch might be local only or already up to date
+  if (fetchExitCode !== 0) {
+    const fetchError = await new Response(fetchProc.stderr).text()
+    console.warn(`⚠️ Warning: Could not fetch latest changes from remote: ${fetchError.trim() || 'unknown error'}`)
+    console.warn(`   Proceeding with local branch state. Your worktree may not have the latest remote changes.`)
+  }
+
+  // Check if branch exists locally
+  const checkProc = Bun.spawn(
+    ['git', '--git-dir', gitDir, 'rev-parse', '--verify', `refs/heads/${branch}`],
+    {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  )
+
+  const branchExists = (await checkProc.exited) === 0
+
+  // Create worktree with the branch
+  // If branch exists locally, just use it
+  // If not, create it tracking origin/{branch}
+  const worktreeArgs = branchExists
+    ? ['git', '--git-dir', gitDir, 'worktree', 'add', expandedPath, branch]
+    : ['git', '--git-dir', gitDir, 'worktree', 'add', '-b', branch, expandedPath, `origin/${branch}`]
+
+  const proc = Bun.spawn(worktreeArgs, {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const exitCode = await proc.exited
+
+  if (exitCode !== 0) {
+    const error = await new Response(proc.stderr).text()
+    throw new Error(`Failed to create worktree at '${expandedPath}' for branch '${branch}': ${error.trim()}`)
+  }
+
+  // Set upstream tracking for the branch in the worktree
+  const trackingProc = Bun.spawn(
+    ['git', '-C', expandedPath, 'branch', '--set-upstream-to', `origin/${branch}`, branch],
+    {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  )
+
+  const trackingExitCode = await trackingProc.exited
+  // Log warning if tracking fails - upstream might not exist for new branches
+  if (trackingExitCode !== 0) {
+    const trackingError = await new Response(trackingProc.stderr).text()
+    console.warn(`⚠️ Warning: Could not set upstream tracking: ${trackingError.trim() || 'unknown error'}`)
+    console.warn(`   You may need to run: git push --set-upstream origin ${branch}`)
+  }
+}
+
+/**
+ * List all worktrees for a repository
+ */
+export async function listWorktrees(bareRepoPath: string): Promise<WorktreeInfo[]> {
+  const proc = Bun.spawn(['git', '-C', bareRepoPath, 'worktree', 'list', '--porcelain'], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const output = await new Response(proc.stdout).text()
+  const exitCode = await proc.exited
+
+  if (exitCode !== 0) {
+    return []
+  }
+
+  const worktrees: WorktreeInfo[] = []
+
+  for (const line of output.trim().split('\n')) {
+    if (!line)
+      continue
+
+    // Parse worktree list porcelain format
+    // Format: "worktree /path/to/worktree"
+    //         "branch /refs/heads/branch-name"
+    //         "detached"
+    //         "prunable" (optional)
+
+    const parts = line.split(' ')
+    if (parts[0] === 'worktree') {
+      const worktreePath = parts.slice(1).join(' ')
+      worktrees.push({
+        path: worktreePath,
+        branch: '',
+        commit: '',
+        prunable: false,
+      })
+    }
+    else if (parts[0] === 'branch' && worktrees.length > 0) {
+      const branchRef = parts[1]
+      const branch = branchRef?.replace(/^refs\/heads\//, '') || ''
+      worktrees[worktrees.length - 1]!.branch = branch
+    }
+    else if (parts[0] === 'detached' && worktrees.length > 0) {
+      worktrees[worktrees.length - 1]!.branch = 'detached'
+    }
+    else if (parts[0] === 'HEAD' && worktrees.length > 0) {
+      worktrees[worktrees.length - 1]!.commit = parts[1] || ''
+    }
+    else if (parts[0] === 'prunable' && worktrees.length > 0) {
+      worktrees[worktrees.length - 1]!.prunable = true
+    }
+  }
+
+  return worktrees
+}
+
+/**
+ * Remove worktree at path
+ */
+export async function removeWorktree(worktreePath: string): Promise<void> {
+  const proc = Bun.spawn(['git', 'worktree', 'remove', worktreePath], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const exitCode = await proc.exited
+
+  if (exitCode !== 0) {
+    const error = await new Response(proc.stderr).text()
+    throw new Error(`Failed to remove worktree: ${error.trim()}`)
+  }
+}

--- a/src/lib/git-workflow-worktree.ts
+++ b/src/lib/git-workflow-worktree.ts
@@ -9,6 +9,10 @@ import { runGitCommand, warnWithFollowup } from './git-exec'
  * @returns The expanded absolute path
  */
 async function ensureParentDirectory(targetPath: string): Promise<string> {
+  // Validate HOME is set when expanding tilde
+  if (targetPath.startsWith('~') && !process.env.HOME) {
+    throw new Error('Cannot expand ~: HOME environment variable is not set')
+  }
   const expandedPath = targetPath.replace(/^~/, process.env.HOME || '')
   const parentDir = path.dirname(expandedPath)
   try {
@@ -72,7 +76,7 @@ export async function createWorktreeFromRepo(
   // Step 2: Update local branch to match remote (if fetch succeeded)
   // This ensures the worktree uses the latest code, not stale local branch
   // Using -f flag: creates branch if not exists, updates if exists
-  await runGitCommand([
+  const branchResult = await runGitCommand([
     'git',
     '--git-dir',
     gitDir,
@@ -81,7 +85,20 @@ export async function createWorktreeFromRepo(
     branch,
     `refs/remotes/origin/${branch}`,
   ])
-  // Ignore update errors - origin/branch might not exist for local-only branches
+  // Only ignore errors for local-only branches (remote ref doesn't exist)
+  // Other errors (disk full, permission denied, lock file) should warn the user
+  if (branchResult.exitCode !== 0) {
+    const isLocalOnlyBranch = branchResult.stderr.includes('not a valid object name')
+      || branchResult.stderr.includes('does not point to a valid commit')
+      || branchResult.stderr.includes('Not a valid object name')
+
+    if (!isLocalOnlyBranch) {
+      warnWithFollowup(
+        `Could not update local branch '${branch}': ${branchResult.stderr.trim() || 'unknown error'}`,
+        'The worktree will be created, but may not have the latest remote changes.',
+      )
+    }
+  }
 
   // Check if branch exists locally (for worktree add command selection)
   const checkResult = await runGitCommand(['git', '--git-dir', gitDir, 'rev-parse', '--verify', `refs/heads/${branch}`])
@@ -114,6 +131,12 @@ export async function listWorktrees(bareRepoPath: string): Promise<WorktreeInfo[
   const result = await runGitCommand(['git', '-C', bareRepoPath, 'worktree', 'list', '--porcelain'])
 
   if (result.exitCode !== 0) {
+    // Log warning for debugging but return empty to allow caller to continue
+    // This is a degraded operation - helps diagnose issues without breaking workflow
+    warnWithFollowup(
+      `Could not list worktrees for ${bareRepoPath}: ${result.stderr.trim() || 'unknown error'}`,
+      'Worktree listing may be incomplete. Check if the repository path is correct.',
+    )
     return []
   }
 

--- a/src/lib/git-workflow-worktree.ts
+++ b/src/lib/git-workflow-worktree.ts
@@ -1,6 +1,7 @@
 import type { WorktreeInfo } from '../types'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { runGitCommand, warnWithFollowup } from './git-exec'
 
 /**
  * Ensure parent directory exists for a target path
@@ -29,19 +30,10 @@ export async function createWorktree(
 ): Promise<void> {
   const expandedPath = await ensureParentDirectory(targetPath)
 
-  const proc = Bun.spawn(
-    ['git', '-C', bareRepoPath, 'worktree', 'add', expandedPath, branch],
-    {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-  )
+  const result = await runGitCommand(['git', '-C', bareRepoPath, 'worktree', 'add', expandedPath, branch])
 
-  const exitCode = await proc.exited
-
-  if (exitCode !== 0) {
-    const error = await new Response(proc.stderr).text()
-    throw new Error(`Failed to create worktree: ${error.trim()}`)
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to create worktree: ${result.stderr.trim()}`)
   }
 }
 
@@ -58,32 +50,17 @@ export async function createWorktreeFromRepo(
   const expandedPath = await ensureParentDirectory(targetPath)
 
   // First, fetch the branch to ensure we have the latest
-  const fetchProc = Bun.spawn(
-    ['git', '--git-dir', gitDir, 'fetch', 'origin', branch],
-    {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-  )
-
-  const fetchExitCode = await fetchProc.exited
-  // Log warning if fetch fails - branch might be local only or already up to date
-  if (fetchExitCode !== 0) {
-    const fetchError = await new Response(fetchProc.stderr).text()
-    console.warn(`⚠️ Warning: Could not fetch latest changes from remote: ${fetchError.trim() || 'unknown error'}`)
-    console.warn(`   Proceeding with local branch state. Your worktree may not have the latest remote changes.`)
+  const fetchResult = await runGitCommand(['git', '--git-dir', gitDir, 'fetch', 'origin', branch])
+  if (fetchResult.exitCode !== 0) {
+    warnWithFollowup(
+      `Could not fetch latest changes from remote: ${fetchResult.stderr.trim() || 'unknown error'}`,
+      'Proceeding with local branch state. Your worktree may not have the latest remote changes.',
+    )
   }
 
   // Check if branch exists locally
-  const checkProc = Bun.spawn(
-    ['git', '--git-dir', gitDir, 'rev-parse', '--verify', `refs/heads/${branch}`],
-    {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-  )
-
-  const branchExists = (await checkProc.exited) === 0
+  const checkResult = await runGitCommand(['git', '--git-dir', gitDir, 'rev-parse', '--verify', `refs/heads/${branch}`])
+  const branchExists = checkResult.exitCode === 0
 
   // Create worktree with the branch
   // If branch exists locally, just use it
@@ -92,33 +69,18 @@ export async function createWorktreeFromRepo(
     ? ['git', '--git-dir', gitDir, 'worktree', 'add', expandedPath, branch]
     : ['git', '--git-dir', gitDir, 'worktree', 'add', '-b', branch, expandedPath, `origin/${branch}`]
 
-  const proc = Bun.spawn(worktreeArgs, {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
-
-  const exitCode = await proc.exited
-
-  if (exitCode !== 0) {
-    const error = await new Response(proc.stderr).text()
-    throw new Error(`Failed to create worktree at '${expandedPath}' for branch '${branch}': ${error.trim()}`)
+  const worktreeResult = await runGitCommand(worktreeArgs)
+  if (worktreeResult.exitCode !== 0) {
+    throw new Error(`Failed to create worktree at '${expandedPath}' for branch '${branch}': ${worktreeResult.stderr.trim()}`)
   }
 
   // Set upstream tracking for the branch in the worktree
-  const trackingProc = Bun.spawn(
-    ['git', '-C', expandedPath, 'branch', '--set-upstream-to', `origin/${branch}`, branch],
-    {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-  )
-
-  const trackingExitCode = await trackingProc.exited
-  // Log warning if tracking fails - upstream might not exist for new branches
-  if (trackingExitCode !== 0) {
-    const trackingError = await new Response(trackingProc.stderr).text()
-    console.warn(`⚠️ Warning: Could not set upstream tracking: ${trackingError.trim() || 'unknown error'}`)
-    console.warn(`   You may need to run: git push --set-upstream origin ${branch}`)
+  const trackingResult = await runGitCommand(['git', '-C', expandedPath, 'branch', '--set-upstream-to', `origin/${branch}`, branch])
+  if (trackingResult.exitCode !== 0) {
+    warnWithFollowup(
+      `Could not set upstream tracking: ${trackingResult.stderr.trim() || 'unknown error'}`,
+      `You may need to run: git push --set-upstream origin ${branch}`,
+    )
   }
 }
 
@@ -126,53 +88,50 @@ export async function createWorktreeFromRepo(
  * List all worktrees for a repository
  */
 export async function listWorktrees(bareRepoPath: string): Promise<WorktreeInfo[]> {
-  const proc = Bun.spawn(['git', '-C', bareRepoPath, 'worktree', 'list', '--porcelain'], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
+  const result = await runGitCommand(['git', '-C', bareRepoPath, 'worktree', 'list', '--porcelain'])
 
-  const output = await new Response(proc.stdout).text()
-  const exitCode = await proc.exited
-
-  if (exitCode !== 0) {
+  if (result.exitCode !== 0) {
     return []
   }
 
+  return parseWorktreeOutput(result.stdout)
+}
+
+/**
+ * Parse git worktree list --porcelain output
+ */
+function parseWorktreeOutput(output: string): WorktreeInfo[] {
   const worktrees: WorktreeInfo[] = []
 
   for (const line of output.trim().split('\n')) {
     if (!line)
       continue
 
-    // Parse worktree list porcelain format
-    // Format: "worktree /path/to/worktree"
-    //         "branch /refs/heads/branch-name"
-    //         "detached"
-    //         "prunable" (optional)
-
     const parts = line.split(' ')
-    if (parts[0] === 'worktree') {
-      const worktreePath = parts.slice(1).join(' ')
+    const key = parts[0]
+
+    if (key === 'worktree') {
       worktrees.push({
-        path: worktreePath,
+        path: parts.slice(1).join(' '),
         branch: '',
         commit: '',
         prunable: false,
       })
     }
-    else if (parts[0] === 'branch' && worktrees.length > 0) {
-      const branchRef = parts[1]
-      const branch = branchRef?.replace(/^refs\/heads\//, '') || ''
-      worktrees[worktrees.length - 1]!.branch = branch
-    }
-    else if (parts[0] === 'detached' && worktrees.length > 0) {
-      worktrees[worktrees.length - 1]!.branch = 'detached'
-    }
-    else if (parts[0] === 'HEAD' && worktrees.length > 0) {
-      worktrees[worktrees.length - 1]!.commit = parts[1] || ''
-    }
-    else if (parts[0] === 'prunable' && worktrees.length > 0) {
-      worktrees[worktrees.length - 1]!.prunable = true
+    else if (worktrees.length > 0) {
+      const current = worktrees[worktrees.length - 1]!
+      if (key === 'branch') {
+        current.branch = parts[1]?.replace(/^refs\/heads\//, '') || ''
+      }
+      else if (key === 'detached') {
+        current.branch = 'detached'
+      }
+      else if (key === 'HEAD') {
+        current.commit = parts[1] || ''
+      }
+      else if (key === 'prunable') {
+        current.prunable = true
+      }
     }
   }
 
@@ -183,15 +142,9 @@ export async function listWorktrees(bareRepoPath: string): Promise<WorktreeInfo[
  * Remove worktree at path
  */
 export async function removeWorktree(worktreePath: string): Promise<void> {
-  const proc = Bun.spawn(['git', 'worktree', 'remove', worktreePath], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
+  const result = await runGitCommand(['git', 'worktree', 'remove', worktreePath])
 
-  const exitCode = await proc.exited
-
-  if (exitCode !== 0) {
-    const error = await new Response(proc.stderr).text()
-    throw new Error(`Failed to remove worktree: ${error.trim()}`)
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to remove worktree: ${result.stderr.trim()}`)
   }
 }

--- a/src/lib/git-workflow-worktree.ts
+++ b/src/lib/git-workflow-worktree.ts
@@ -73,26 +73,34 @@ export async function createWorktreeFromRepo(
     }
   }
 
-  // Step 2: Update local branch to match remote (if fetch succeeded)
-  // This ensures the worktree uses the latest code, not stale local branch
-  // Using -f flag: creates branch if not exists, updates if exists
-  const branchResult = await runGitCommand([
+  // Step 2: Check if remote-tracking ref exists before updating local branch
+  // Using rev-parse is language-agnostic (avoids relying on localized error messages)
+  const remoteRefCheck = await runGitCommand([
     'git',
     '--git-dir',
     gitDir,
-    'branch',
-    '-f',
-    branch,
+    'rev-parse',
+    '--verify',
+    '--quiet',
     `refs/remotes/origin/${branch}`,
   ])
-  // Only ignore errors for local-only branches (remote ref doesn't exist)
-  // Other errors (disk full, permission denied, lock file) should warn the user
-  if (branchResult.exitCode !== 0) {
-    const isLocalOnlyBranch = branchResult.stderr.includes('not a valid object name')
-      || branchResult.stderr.includes('does not point to a valid commit')
-      || branchResult.stderr.includes('Not a valid object name')
+  const remoteRefExists = remoteRefCheck.exitCode === 0
 
-    if (!isLocalOnlyBranch) {
+  // Step 3: Update local branch to match remote (only if remote ref exists)
+  // This ensures the worktree uses the latest code, not stale local branch
+  if (remoteRefExists) {
+    const branchResult = await runGitCommand([
+      'git',
+      '--git-dir',
+      gitDir,
+      'branch',
+      '-f',
+      branch,
+      `refs/remotes/origin/${branch}`,
+    ])
+    // Warn for real errors (disk full, permission denied, lock file)
+    // Skip warning for local-only branches (handled by remoteRefExists check)
+    if (branchResult.exitCode !== 0) {
       warnWithFollowup(
         `Could not update local branch '${branch}': ${branchResult.stderr.trim() || 'unknown error'}`,
         'The worktree will be created, but may not have the latest remote changes.',

--- a/src/lib/git-workflow.ts
+++ b/src/lib/git-workflow.ts
@@ -1,6 +1,12 @@
-import type { DevelopOptions, WorktreeInfo } from '../types'
-import * as fs from 'node:fs'
-import * as path from 'node:path'
+import type { DevelopOptions } from '../types'
+
+// Re-export worktree functions from dedicated module
+export {
+  createWorktree,
+  createWorktreeFromRepo,
+  listWorktrees,
+  removeWorktree,
+} from './git-workflow-worktree'
 
 /**
  * Get the gh command path from environment variable or use default
@@ -178,99 +184,6 @@ export async function startDevelopWorkflow(
 }
 
 /**
- * Create worktree at target path using git worktree add
- */
-export async function createWorktree(
-  bareRepoPath: string,
-  branch: string,
-  targetPath: string,
-): Promise<void> {
-  // Expand ~ to home directory
-  const expandedPath = targetPath.replace(/^~/, process.env.HOME || '')
-
-  // Create parent directories if needed
-  const parentDir = path.dirname(expandedPath)
-  try {
-    await fs.promises.mkdir(parentDir, { recursive: true })
-  }
-  catch (error) {
-    throw new Error(`Failed to create directory ${parentDir}: ${error instanceof Error ? error.message : String(error)}`)
-  }
-
-  const proc = Bun.spawn(
-    ['git', '-C', bareRepoPath, 'worktree', 'add', expandedPath, branch],
-    {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-  )
-
-  const exitCode = await proc.exited
-
-  if (exitCode !== 0) {
-    const error = await new Response(proc.stderr).text()
-    throw new Error(`Failed to create worktree: ${error.trim()}`)
-  }
-}
-
-/**
- * List all worktrees for a repository
- */
-export async function listWorktrees(bareRepoPath: string): Promise<WorktreeInfo[]> {
-  const proc = Bun.spawn(['git', '-C', bareRepoPath, 'worktree', 'list', '--porcelain'], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
-
-  const output = await new Response(proc.stdout).text()
-  const exitCode = await proc.exited
-
-  if (exitCode !== 0) {
-    return []
-  }
-
-  const worktrees: WorktreeInfo[] = []
-
-  for (const line of output.trim().split('\n')) {
-    if (!line)
-      continue
-
-    // Parse worktree list porcelain format
-    // Format: "worktree /path/to/worktree"
-    //         "branch /refs/heads/branch-name"
-    //         "detached"
-    //         "prunable" (optional)
-
-    const parts = line.split(' ')
-    if (parts[0] === 'worktree') {
-      const worktreePath = parts.slice(1).join(' ')
-      worktrees.push({
-        path: worktreePath,
-        branch: '',
-        commit: '',
-        prunable: false,
-      })
-    }
-    else if (parts[0] === 'branch' && worktrees.length > 0) {
-      const branchRef = parts[1]
-      const branch = branchRef?.replace(/^refs\/heads\//, '') || ''
-      worktrees[worktrees.length - 1]!.branch = branch
-    }
-    else if (parts[0] === 'detached' && worktrees.length > 0) {
-      worktrees[worktrees.length - 1]!.branch = 'detached'
-    }
-    else if (parts[0] === 'HEAD' && worktrees.length > 0) {
-      worktrees[worktrees.length - 1]!.commit = parts[1] || ''
-    }
-    else if (parts[0] === 'prunable' && worktrees.length > 0) {
-      worktrees[worktrees.length - 1]!.prunable = true
-    }
-  }
-
-  return worktrees
-}
-
-/**
  * Fetch branch from remote into a bare repository with proper remote tracking
  * Uses two-step approach:
  * 1. Fetch to refs/remotes/origin/{branch} for remote tracking
@@ -325,98 +238,4 @@ export async function fetchBranch(
       throw new Error(`Failed to update local branch: ${error.trim()}`)
     }
   }
-}
-
-/**
- * Remove worktree at path
- */
-export async function removeWorktree(worktreePath: string): Promise<void> {
-  const proc = Bun.spawn(['git', 'worktree', 'remove', worktreePath], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
-
-  const exitCode = await proc.exited
-
-  if (exitCode !== 0) {
-    const error = await new Response(proc.stderr).text()
-    throw new Error(`Failed to remove worktree: ${error.trim()}`)
-  }
-}
-
-/**
- * Create worktree from a cloned repository (non-bare)
- * Uses the existing repo's git directory to create worktree
- * This ensures proper remote tracking for fetch operations in the worktree
- */
-export async function createWorktreeFromRepo(
-  gitDir: string,
-  branch: string,
-  targetPath: string,
-): Promise<void> {
-  // Expand ~ to home directory
-  const expandedPath = targetPath.replace(/^~/, process.env.HOME || '')
-
-  // Create parent directories if needed
-  const parentDir = path.dirname(expandedPath)
-  try {
-    await fs.promises.mkdir(parentDir, { recursive: true })
-  }
-  catch (error) {
-    throw new Error(`Failed to create directory ${parentDir}: ${error instanceof Error ? error.message : String(error)}`)
-  }
-
-  // First, fetch the branch to ensure we have the latest
-  const fetchProc = Bun.spawn(
-    ['git', '--git-dir', gitDir, 'fetch', 'origin', branch],
-    {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-  )
-
-  await fetchProc.exited
-  // Ignore fetch errors - branch might be local only or already up to date
-
-  // Check if branch exists locally
-  const checkProc = Bun.spawn(
-    ['git', '--git-dir', gitDir, 'rev-parse', '--verify', `refs/heads/${branch}`],
-    {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-  )
-
-  const branchExists = (await checkProc.exited) === 0
-
-  // Create worktree with the branch
-  // If branch exists locally, just use it
-  // If not, create it tracking origin/{branch}
-  const worktreeArgs = branchExists
-    ? ['git', '--git-dir', gitDir, 'worktree', 'add', expandedPath, branch]
-    : ['git', '--git-dir', gitDir, 'worktree', 'add', '-b', branch, expandedPath, `origin/${branch}`]
-
-  const proc = Bun.spawn(worktreeArgs, {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  })
-
-  const exitCode = await proc.exited
-
-  if (exitCode !== 0) {
-    const error = await new Response(proc.stderr).text()
-    throw new Error(`Failed to create worktree: ${error.trim()}`)
-  }
-
-  // Set upstream tracking for the branch in the worktree
-  const trackingProc = Bun.spawn(
-    ['git', '-C', expandedPath, 'branch', '--set-upstream-to', `origin/${branch}`, branch],
-    {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    },
-  )
-
-  await trackingProc.exited
-  // Ignore tracking errors - upstream might not exist for new branches
 }

--- a/src/lib/git-workflow.ts
+++ b/src/lib/git-workflow.ts
@@ -1,4 +1,5 @@
 import type { DevelopOptions } from '../types'
+import { getGhCommand } from './gh-command'
 
 // Re-export worktree functions from dedicated module
 export {
@@ -7,13 +8,6 @@ export {
   listWorktrees,
   removeWorktree,
 } from './git-workflow-worktree'
-
-/**
- * Get the gh command path from environment variable or use default
- */
-function getGhCommand(): string {
-  return process.env.GH_PATH || 'gh'
-}
 
 /**
  * Get all linked branches for an issue using GitHub GraphQL API

--- a/src/lib/git-workflow.ts
+++ b/src/lib/git-workflow.ts
@@ -271,25 +271,59 @@ export async function listWorktrees(bareRepoPath: string): Promise<WorktreeInfo[
 }
 
 /**
- * Fetch branch from remote into a bare repository
+ * Fetch branch from remote into a bare repository with proper remote tracking
+ * Uses two-step approach:
+ * 1. Fetch to refs/remotes/origin/{branch} for remote tracking
+ * 2. Create/update local branch pointing to the same commit
  */
 export async function fetchBranch(
   bareRepoPath: string,
   branch: string,
 ): Promise<void> {
-  const proc = Bun.spawn(
-    ['git', '-C', bareRepoPath, 'fetch', 'origin', `${branch}:${branch}`],
+  // Step 1: Fetch to remote tracking branch (refs/remotes/origin/{branch})
+  const fetchProc = Bun.spawn(
+    ['git', '-C', bareRepoPath, 'fetch', 'origin', `${branch}:refs/remotes/origin/${branch}`],
     {
       stdout: 'pipe',
       stderr: 'pipe',
     },
   )
 
-  const exitCode = await proc.exited
+  const fetchExitCode = await fetchProc.exited
 
-  if (exitCode !== 0) {
-    const error = await new Response(proc.stderr).text()
+  if (fetchExitCode !== 0) {
+    const error = await new Response(fetchProc.stderr).text()
     throw new Error(`Failed to fetch branch: ${error.trim()}`)
+  }
+
+  // Step 2: Create or update local branch from remote tracking branch
+  // Try to create the branch first
+  const createProc = Bun.spawn(
+    ['git', '-C', bareRepoPath, 'branch', branch, `refs/remotes/origin/${branch}`],
+    {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  )
+
+  const createExitCode = await createProc.exited
+
+  if (createExitCode !== 0) {
+    // Branch might already exist, try to update it
+    const updateProc = Bun.spawn(
+      ['git', '-C', bareRepoPath, 'branch', '-f', branch, `refs/remotes/origin/${branch}`],
+      {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+
+    const updateExitCode = await updateProc.exited
+
+    if (updateExitCode !== 0) {
+      const error = await new Response(updateProc.stderr).text()
+      throw new Error(`Failed to update local branch: ${error.trim()}`)
+    }
   }
 }
 
@@ -308,4 +342,81 @@ export async function removeWorktree(worktreePath: string): Promise<void> {
     const error = await new Response(proc.stderr).text()
     throw new Error(`Failed to remove worktree: ${error.trim()}`)
   }
+}
+
+/**
+ * Create worktree from a cloned repository (non-bare)
+ * Uses the existing repo's git directory to create worktree
+ * This ensures proper remote tracking for fetch operations in the worktree
+ */
+export async function createWorktreeFromRepo(
+  gitDir: string,
+  branch: string,
+  targetPath: string,
+): Promise<void> {
+  // Expand ~ to home directory
+  const expandedPath = targetPath.replace(/^~/, process.env.HOME || '')
+
+  // Create parent directories if needed
+  const parentDir = path.dirname(expandedPath)
+  try {
+    await fs.promises.mkdir(parentDir, { recursive: true })
+  }
+  catch (error) {
+    throw new Error(`Failed to create directory ${parentDir}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  // First, fetch the branch to ensure we have the latest
+  const fetchProc = Bun.spawn(
+    ['git', '--git-dir', gitDir, 'fetch', 'origin', branch],
+    {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  )
+
+  await fetchProc.exited
+  // Ignore fetch errors - branch might be local only or already up to date
+
+  // Check if branch exists locally
+  const checkProc = Bun.spawn(
+    ['git', '--git-dir', gitDir, 'rev-parse', '--verify', `refs/heads/${branch}`],
+    {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  )
+
+  const branchExists = (await checkProc.exited) === 0
+
+  // Create worktree with the branch
+  // If branch exists locally, just use it
+  // If not, create it tracking origin/{branch}
+  const worktreeArgs = branchExists
+    ? ['git', '--git-dir', gitDir, 'worktree', 'add', expandedPath, branch]
+    : ['git', '--git-dir', gitDir, 'worktree', 'add', '-b', branch, expandedPath, `origin/${branch}`]
+
+  const proc = Bun.spawn(worktreeArgs, {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const exitCode = await proc.exited
+
+  if (exitCode !== 0) {
+    const error = await new Response(proc.stderr).text()
+    throw new Error(`Failed to create worktree: ${error.trim()}`)
+  }
+
+  // Set upstream tracking for the branch in the worktree
+  const trackingProc = Bun.spawn(
+    ['git', '-C', expandedPath, 'branch', '--set-upstream-to', `origin/${branch}`, branch],
+    {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  )
+
+  await trackingProc.exited
+  // Ignore tracking errors - upstream might not exist for new branches
 }

--- a/src/lib/repo-manager.ts
+++ b/src/lib/repo-manager.ts
@@ -67,6 +67,26 @@ export async function isInGitRepo(): Promise<boolean> {
 }
 
 /**
+ * Get the .git directory of the current repository
+ * Returns absolute path if in a git repo, null otherwise
+ */
+export async function getGitDir(): Promise<string | null> {
+  const proc = Bun.spawn(['git', 'rev-parse', '--absolute-git-dir'], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const output = await new Response(proc.stdout).text()
+  const exitCode = await proc.exited
+
+  if (exitCode !== 0) {
+    return null
+  }
+
+  return output.trim()
+}
+
+/**
  * Clone repository as bare to ~/.please/repositories/{owner}/{repo}.git
  */
 export async function cloneBareRepo(owner: string, repo: string): Promise<string> {
@@ -126,13 +146,15 @@ async function getCurrentRepoInfo(): Promise<{ owner: string, repo: string }> {
 
 /**
  * Resolve repository information from --repo flag or current directory
+ * When inside a cloned repo without --repo flag, returns gitDir for worktree operations
  */
 export async function resolveRepository(repoFlag?: string): Promise<RepositoryInfo> {
   let owner: string
   let repo: string
+  let gitDir: string | undefined
 
   if (repoFlag) {
-    // Parse from --repo flag
+    // Parse from --repo flag - use bare repo mode
     const parsed = parseRepoString(repoFlag)
     owner = parsed.owner
     repo = parsed.repo
@@ -147,6 +169,9 @@ export async function resolveRepository(repoFlag?: string): Promise<RepositoryIn
     const currentRepo = await getCurrentRepoInfo()
     owner = currentRepo.owner
     repo = currentRepo.repo
+
+    // Get gitDir for non-bare mode (worktree from current repo)
+    gitDir = (await getGitDir()) ?? undefined
   }
 
   const bareRepoPath = path.join(os.homedir(), '.please', 'repositories', owner, `${repo}.git`)
@@ -155,6 +180,7 @@ export async function resolveRepository(repoFlag?: string): Promise<RepositoryIn
     owner,
     repo,
     localPath: bareRepoPath,
-    isBare: true,
+    isBare: !gitDir, // false when we have gitDir (inside cloned repo without --repo)
+    gitDir,
   }
 }

--- a/src/lib/repo-manager.ts
+++ b/src/lib/repo-manager.ts
@@ -80,6 +80,8 @@ export async function getGitDir(): Promise<string | null> {
   const exitCode = await proc.exited
 
   if (exitCode !== 0) {
+    // Consume stderr to prevent potential pipe issues
+    await new Response(proc.stderr).text()
     return null
   }
 

--- a/src/lib/repo-manager.ts
+++ b/src/lib/repo-manager.ts
@@ -2,13 +2,7 @@ import type { RepositoryInfo } from '../types'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-
-/**
- * Get the gh command path from environment variable or use default
- */
-function getGhCommand(): string {
-  return process.env.GH_PATH || 'gh'
-}
+import { getGhCommand } from './gh-command'
 
 /**
  * Parse repository string in format "owner/repo" or GitHub URL

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,8 +73,9 @@ export interface DevelopOptions {
 export interface RepositoryInfo {
   owner: string
   repo: string
-  localPath: string // ~/repos/owner/repo.git
+  localPath: string // ~/repos/owner/repo.git (bare repo path)
   isBare: boolean
+  gitDir?: string // Current repo's .git directory (for non-bare mode)
 }
 
 export interface WorktreeInfo {

--- a/test/lib/git-workflow-worktree.preload.ts
+++ b/test/lib/git-workflow-worktree.preload.ts
@@ -1,0 +1,30 @@
+import * as originalFs from 'node:fs'
+/**
+ * Preload file for git-workflow-worktree tests
+ * This file is loaded BEFORE any test imports, allowing us to mock modules
+ * before they are imported by the code under test.
+ *
+ * Run tests with: bun test test/lib/git-workflow-worktree.test.ts --preload ./test/lib/git-workflow-worktree.preload.ts
+ */
+import { mock } from 'bun:test'
+
+// Create mock functions that will be exported
+export const mockRunGitCommand = mock()
+export const mockWarnWithFollowup = mock()
+export const mockMkdir = mock(() => Promise.resolve())
+
+// Mock git-exec module BEFORE it's imported
+mock.module('../../src/lib/git-exec', () => ({
+  runGitCommand: mockRunGitCommand,
+  warnWithFollowup: mockWarnWithFollowup,
+}))
+
+// Mock only fs.promises.mkdir while preserving other fs functions
+mock.module('node:fs', () => ({
+  ...originalFs,
+  default: originalFs,
+  promises: {
+    ...originalFs.promises,
+    mkdir: mockMkdir,
+  },
+}))

--- a/test/lib/git-workflow-worktree.test.ts
+++ b/test/lib/git-workflow-worktree.test.ts
@@ -71,6 +71,20 @@ describe('createWorktree (bare repo)', () => {
 
     process.env.HOME = originalHome
   })
+
+  test('should throw error when HOME is undefined and path starts with tilde', async () => {
+    const originalHome = process.env.HOME
+    delete process.env.HOME
+
+    try {
+      expect(createWorktree('/path/to/bare.git', 'branch', '~/worktrees/test'))
+        .rejects
+        .toThrow('Cannot expand ~: HOME environment variable is not set')
+    }
+    finally {
+      process.env.HOME = originalHome
+    }
+  })
 })
 
 describe('createWorktreeFromRepo (cloned repo)', () => {
@@ -191,6 +205,43 @@ describe('createWorktreeFromRepo (cloned repo)', () => {
     expect(mockWarnWithFollowup).not.toHaveBeenCalled()
   })
 
+  test('should warn when branch update fails (not local-only)', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch succeeds
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: Unable to create lock file',
+    }) // branch -f fails (lock file error)
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
+
+    await createWorktreeFromRepo('/path/to/.git', 'branch', '/tmp/wt')
+
+    // Should warn about branch update failure
+    expect(mockWarnWithFollowup).toHaveBeenCalledWith(
+      'Could not update local branch \'branch\': fatal: Unable to create lock file',
+      'The worktree will be created, but may not have the latest remote changes.',
+    )
+  })
+
+  test('should not warn when branch update fails due to local-only branch', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch succeeds
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: not a valid object name',
+    }) // branch -f fails (local-only - remote ref doesn't exist)
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
+
+    await createWorktreeFromRepo('/path/to/.git', 'local-branch', '/tmp/wt')
+
+    // Should NOT warn for local-only branches
+    expect(mockWarnWithFollowup).not.toHaveBeenCalled()
+  })
+
   test('should warn when upstream tracking setup fails', async () => {
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
@@ -280,7 +331,7 @@ prunable
     })
   })
 
-  test('should return empty array when git worktree list fails', async () => {
+  test('should return empty array and warn when git worktree list fails', async () => {
     mockRunGitCommand.mockResolvedValueOnce({
       exitCode: 1,
       stdout: '',
@@ -290,6 +341,10 @@ prunable
     const result = await listWorktrees('/invalid/path')
 
     expect(result).toEqual([])
+    expect(mockWarnWithFollowup).toHaveBeenCalledWith(
+      'Could not list worktrees for /invalid/path: fatal: not a git repository',
+      'Worktree listing may be incomplete. Check if the repository path is correct.',
+    )
   })
 
   test('should handle worktree paths with spaces', async () => {

--- a/test/lib/git-workflow-worktree.test.ts
+++ b/test/lib/git-workflow-worktree.test.ts
@@ -77,7 +77,7 @@ describe('createWorktree (bare repo)', () => {
     delete process.env.HOME
 
     try {
-      expect(createWorktree('/path/to/bare.git', 'branch', '~/worktrees/test'))
+      await expect(createWorktree('/path/to/bare.git', 'branch', '~/worktrees/test'))
         .rejects
         .toThrow('Cannot expand ~: HOME environment variable is not set')
     }
@@ -91,13 +91,15 @@ describe('createWorktreeFromRepo (cloned repo)', () => {
   test('should fetch with explicit refspec to update remote-tracking branch', async () => {
     // Step 1: Fetch succeeds
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
-    // Step 2: Branch update succeeds
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
-    // Step 3: Branch exists check
+    // Step 2: Remote ref check succeeds
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' })
-    // Step 4: Worktree add succeeds
+    // Step 3: Branch update succeeds
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
-    // Step 5: Set upstream tracking succeeds
+    // Step 4: Local branch exists check
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' })
+    // Step 5: Worktree add succeeds
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+    // Step 6: Set upstream tracking succeeds
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
 
     await createWorktreeFromRepo('/path/to/.git', 'feature-123', '/tmp/worktree')
@@ -112,8 +114,19 @@ describe('createWorktreeFromRepo (cloned repo)', () => {
       'feature-123:refs/remotes/origin/feature-123',
     ]])
 
-    // Verify local branch update with -f flag
+    // Verify remote ref check (rev-parse --verify)
     expect(mockRunGitCommand.mock.calls[1]).toEqual([[
+      'git',
+      '--git-dir',
+      '/path/to/.git',
+      'rev-parse',
+      '--verify',
+      '--quiet',
+      'refs/remotes/origin/feature-123',
+    ]])
+
+    // Verify local branch update with -f flag
+    expect(mockRunGitCommand.mock.calls[2]).toEqual([[
       'git',
       '--git-dir',
       '/path/to/.git',
@@ -126,15 +139,16 @@ describe('createWorktreeFromRepo (cloned repo)', () => {
 
   test('should use existing local branch when it exists', async () => {
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // remote ref exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // local branch exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
 
     await createWorktreeFromRepo('/path/to/.git', 'existing-branch', '/tmp/wt')
 
     // Worktree add should use existing branch (no -b flag)
-    expect(mockRunGitCommand.mock.calls[3]).toEqual([[
+    expect(mockRunGitCommand.mock.calls[4]).toEqual([[
       'git',
       '--git-dir',
       '/path/to/.git',
@@ -147,15 +161,16 @@ describe('createWorktreeFromRepo (cloned repo)', () => {
 
   test('should create new branch from origin when local branch does not exist', async () => {
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // remote ref exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'fatal: not found' }) // branch not exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'fatal: not found' }) // local branch not exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
 
     await createWorktreeFromRepo('/path/to/.git', 'new-branch', '/tmp/wt')
 
     // Worktree add should create new branch with -b flag
-    expect(mockRunGitCommand.mock.calls[3]).toEqual([[
+    expect(mockRunGitCommand.mock.calls[4]).toEqual([[
       'git',
       '--git-dir',
       '/path/to/.git',
@@ -174,8 +189,9 @@ describe('createWorktreeFromRepo (cloned repo)', () => {
       stdout: '',
       stderr: 'fatal: network error',
     }) // fetch fails
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: '' }) // remote ref check fails
+    // branch -f skipped (no remote ref)
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // local branch exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
 
@@ -194,8 +210,9 @@ describe('createWorktreeFromRepo (cloned repo)', () => {
       stdout: '',
       stderr: 'fatal: couldn\'t find remote ref local-only-branch',
     }) // fetch fails - local only
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: '' }) // remote ref check fails
+    // branch -f skipped (no remote ref)
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // local branch exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
 
@@ -205,14 +222,15 @@ describe('createWorktreeFromRepo (cloned repo)', () => {
     expect(mockWarnWithFollowup).not.toHaveBeenCalled()
   })
 
-  test('should warn when branch update fails (not local-only)', async () => {
+  test('should warn when branch update fails', async () => {
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch succeeds
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // remote ref exists
     mockRunGitCommand.mockResolvedValueOnce({
       exitCode: 1,
       stdout: '',
       stderr: 'fatal: Unable to create lock file',
     }) // branch -f fails (lock file error)
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // local branch exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
 
@@ -225,27 +243,27 @@ describe('createWorktreeFromRepo (cloned repo)', () => {
     )
   })
 
-  test('should not warn when branch update fails due to local-only branch', async () => {
+  test('should skip branch update when remote ref does not exist (local-only branch)', async () => {
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch succeeds
-    mockRunGitCommand.mockResolvedValueOnce({
-      exitCode: 1,
-      stdout: '',
-      stderr: 'fatal: not a valid object name',
-    }) // branch -f fails (local-only - remote ref doesn't exist)
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: '' }) // remote ref doesn't exist
+    // branch -f skipped (no remote ref)
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // local branch exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
 
     await createWorktreeFromRepo('/path/to/.git', 'local-branch', '/tmp/wt')
 
-    // Should NOT warn for local-only branches
+    // Should NOT warn - branch update was skipped for local-only branch
     expect(mockWarnWithFollowup).not.toHaveBeenCalled()
+    // Should only have 5 calls (no branch -f)
+    expect(mockRunGitCommand).toHaveBeenCalledTimes(5)
   })
 
   test('should warn when upstream tracking setup fails', async () => {
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // remote ref exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // local branch exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
     mockRunGitCommand.mockResolvedValueOnce({
       exitCode: 1,
@@ -263,8 +281,9 @@ describe('createWorktreeFromRepo (cloned repo)', () => {
 
   test('should throw error when worktree add fails', async () => {
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // remote ref exists
     mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
-    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // local branch exists
     mockRunGitCommand.mockResolvedValueOnce({
       exitCode: 1,
       stdout: '',

--- a/test/lib/git-workflow-worktree.test.ts
+++ b/test/lib/git-workflow-worktree.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Comprehensive tests for git-workflow-worktree.ts
+ *
+ * These tests verify git command arguments and error handling by mocking
+ * the runGitCommand function. Run with:
+ *   bun test test/lib/git-workflow-worktree.test.ts --preload test/lib/git-workflow-worktree.preload.ts
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  createWorktree,
+  createWorktreeFromRepo,
+  listWorktrees,
+  removeWorktree,
+} from '../../src/lib/git-workflow-worktree'
+import {
+  mockRunGitCommand,
+  mockWarnWithFollowup,
+} from './git-workflow-worktree.preload'
+
+afterEach(() => {
+  mockRunGitCommand.mockClear()
+  mockWarnWithFollowup.mockClear()
+})
+
+describe('createWorktree (bare repo)', () => {
+  test('should call git worktree add with correct arguments', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+
+    await createWorktree('/path/to/bare.git', 'feature-branch', '/tmp/worktree')
+
+    expect(mockRunGitCommand).toHaveBeenCalledWith([
+      'git',
+      '-C',
+      '/path/to/bare.git',
+      'worktree',
+      'add',
+      '/tmp/worktree',
+      'feature-branch',
+    ])
+  })
+
+  test('should throw error when git worktree add fails', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: worktree already exists',
+    })
+
+    expect(createWorktree('/path/to/bare.git', 'feature', '/tmp/wt'))
+      .rejects
+      .toThrow('Failed to create worktree: fatal: worktree already exists')
+  })
+
+  test('should expand tilde in target path', async () => {
+    const originalHome = process.env.HOME
+    process.env.HOME = '/home/testuser'
+
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+
+    await createWorktree('/path/to/bare.git', 'branch', '~/worktrees/test')
+
+    expect(mockRunGitCommand).toHaveBeenCalledWith([
+      'git',
+      '-C',
+      '/path/to/bare.git',
+      'worktree',
+      'add',
+      '/home/testuser/worktrees/test',
+      'branch',
+    ])
+
+    process.env.HOME = originalHome
+  })
+})
+
+describe('createWorktreeFromRepo (cloned repo)', () => {
+  test('should fetch with explicit refspec to update remote-tracking branch', async () => {
+    // Step 1: Fetch succeeds
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+    // Step 2: Branch update succeeds
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+    // Step 3: Branch exists check
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' })
+    // Step 4: Worktree add succeeds
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+    // Step 5: Set upstream tracking succeeds
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+
+    await createWorktreeFromRepo('/path/to/.git', 'feature-123', '/tmp/worktree')
+
+    // Verify fetch uses explicit refspec
+    expect(mockRunGitCommand.mock.calls[0]).toEqual([[
+      'git',
+      '--git-dir',
+      '/path/to/.git',
+      'fetch',
+      'origin',
+      'feature-123:refs/remotes/origin/feature-123',
+    ]])
+
+    // Verify local branch update with -f flag
+    expect(mockRunGitCommand.mock.calls[1]).toEqual([[
+      'git',
+      '--git-dir',
+      '/path/to/.git',
+      'branch',
+      '-f',
+      'feature-123',
+      'refs/remotes/origin/feature-123',
+    ]])
+  })
+
+  test('should use existing local branch when it exists', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
+
+    await createWorktreeFromRepo('/path/to/.git', 'existing-branch', '/tmp/wt')
+
+    // Worktree add should use existing branch (no -b flag)
+    expect(mockRunGitCommand.mock.calls[3]).toEqual([[
+      'git',
+      '--git-dir',
+      '/path/to/.git',
+      'worktree',
+      'add',
+      '/tmp/wt',
+      'existing-branch',
+    ]])
+  })
+
+  test('should create new branch from origin when local branch does not exist', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 1, stdout: '', stderr: 'fatal: not found' }) // branch not exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
+
+    await createWorktreeFromRepo('/path/to/.git', 'new-branch', '/tmp/wt')
+
+    // Worktree add should create new branch with -b flag
+    expect(mockRunGitCommand.mock.calls[3]).toEqual([[
+      'git',
+      '--git-dir',
+      '/path/to/.git',
+      'worktree',
+      'add',
+      '-b',
+      'new-branch',
+      '/tmp/wt',
+      'origin/new-branch',
+    ]])
+  })
+
+  test('should warn when fetch fails (not local-only branch)', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: network error',
+    }) // fetch fails
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
+
+    await createWorktreeFromRepo('/path/to/.git', 'branch', '/tmp/wt')
+
+    // Should warn about fetch failure
+    expect(mockWarnWithFollowup).toHaveBeenCalledWith(
+      'Could not fetch latest changes from remote: fatal: network error',
+      'Proceeding with local branch state. Your worktree may not have the latest remote changes.',
+    )
+  })
+
+  test('should not warn when fetch fails due to local-only branch', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: couldn\'t find remote ref local-only-branch',
+    }) // fetch fails - local only
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // set upstream
+
+    await createWorktreeFromRepo('/path/to/.git', 'local-only-branch', '/tmp/wt')
+
+    // Should NOT warn for local-only branches
+    expect(mockWarnWithFollowup).not.toHaveBeenCalled()
+  })
+
+  test('should warn when upstream tracking setup fails', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // worktree add
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: no upstream configured',
+    }) // set upstream fails
+
+    await createWorktreeFromRepo('/path/to/.git', 'branch', '/tmp/wt')
+
+    expect(mockWarnWithFollowup).toHaveBeenCalledWith(
+      'Could not set upstream tracking: fatal: no upstream configured',
+      'You may need to run: git push --set-upstream origin branch',
+    )
+  })
+
+  test('should throw error when worktree add fails', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // fetch
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' }) // branch -f
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: 'abc123', stderr: '' }) // branch exists
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: worktree already in use',
+    }) // worktree add fails
+
+    expect(createWorktreeFromRepo('/path/to/.git', 'branch', '/tmp/wt'))
+      .rejects
+      .toThrow('Failed to create worktree at \'/tmp/wt\' for branch \'branch\': fatal: worktree already in use')
+  })
+})
+
+describe('listWorktrees', () => {
+  test('should parse porcelain output correctly', async () => {
+    const porcelainOutput = `worktree /path/to/main
+HEAD abc123def456
+branch refs/heads/main
+
+worktree /path/to/feature
+HEAD def456abc789
+branch refs/heads/feature-123
+
+worktree /path/to/detached
+HEAD 111222333444
+detached
+
+worktree /path/to/prunable
+HEAD 555666777888
+branch refs/heads/old-branch
+prunable
+`
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: porcelainOutput,
+      stderr: '',
+    })
+
+    const result = await listWorktrees('/path/to/bare.git')
+
+    expect(result).toHaveLength(4)
+    expect(result[0]).toEqual({
+      path: '/path/to/main',
+      branch: 'main',
+      commit: 'abc123def456',
+      prunable: false,
+    })
+    expect(result[1]).toEqual({
+      path: '/path/to/feature',
+      branch: 'feature-123',
+      commit: 'def456abc789',
+      prunable: false,
+    })
+    expect(result[2]).toEqual({
+      path: '/path/to/detached',
+      branch: 'detached',
+      commit: '111222333444',
+      prunable: false,
+    })
+    expect(result[3]).toEqual({
+      path: '/path/to/prunable',
+      branch: 'old-branch',
+      commit: '555666777888',
+      prunable: true,
+    })
+  })
+
+  test('should return empty array when git worktree list fails', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: not a git repository',
+    })
+
+    const result = await listWorktrees('/invalid/path')
+
+    expect(result).toEqual([])
+  })
+
+  test('should handle worktree paths with spaces', async () => {
+    const porcelainOutput = `worktree /path/with spaces/worktree
+HEAD abc123
+branch refs/heads/main
+`
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: porcelainOutput,
+      stderr: '',
+    })
+
+    const result = await listWorktrees('/path/to/bare.git')
+
+    expect(result[0]?.path).toBe('/path/with spaces/worktree')
+  })
+})
+
+describe('removeWorktree', () => {
+  test('should call git worktree remove with correct path', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+
+    await removeWorktree('/path/to/worktree')
+
+    expect(mockRunGitCommand).toHaveBeenCalledWith([
+      'git',
+      'worktree',
+      'remove',
+      '/path/to/worktree',
+    ])
+  })
+
+  test('should throw error when removal fails', async () => {
+    mockRunGitCommand.mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: worktree has uncommitted changes',
+    })
+
+    expect(removeWorktree('/path/to/worktree'))
+      .rejects
+      .toThrow('Failed to remove worktree: fatal: worktree has uncommitted changes')
+  })
+})

--- a/test/lib/git-workflow.test.ts
+++ b/test/lib/git-workflow.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import {
   createWorktree,
+  createWorktreeFromRepo,
+  fetchBranch,
   getLinkedBranch,
   listWorktrees,
   removeWorktree,
@@ -22,6 +24,18 @@ describe('startDevelopWorkflow', () => {
 describe('createWorktree', () => {
   test('should export createWorktree function', () => {
     expect(typeof createWorktree).toBe('function')
+  })
+})
+
+describe('createWorktreeFromRepo', () => {
+  test('should export createWorktreeFromRepo function', () => {
+    expect(typeof createWorktreeFromRepo).toBe('function')
+  })
+})
+
+describe('fetchBranch', () => {
+  test('should export fetchBranch function', () => {
+    expect(typeof fetchBranch).toBe('function')
   })
 })
 

--- a/test/lib/repo-manager.test.ts
+++ b/test/lib/repo-manager.test.ts
@@ -57,7 +57,10 @@ describe('getGitDir', () => {
   })
 
   test('should return git directory path when in a git repo', async () => {
-    // This test is run from within the gh-please repo
+    // Guard: Skip if not in a git repo (e.g., running in isolated CI environment)
+    if (!(await isInGitRepo()))
+      return
+
     const gitDir = await getGitDir()
     expect(gitDir).not.toBeNull()
     expect(gitDir).toContain('.git')

--- a/test/lib/repo-manager.test.ts
+++ b/test/lib/repo-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   cloneBareRepo,
   findBareRepo,
+  getGitDir,
   isInGitRepo,
   parseRepoString,
   resolveRepository,
@@ -47,6 +48,19 @@ describe('findBareRepo', () => {
 describe('isInGitRepo', () => {
   test('should export isInGitRepo function', () => {
     expect(typeof isInGitRepo).toBe('function')
+  })
+})
+
+describe('getGitDir', () => {
+  test('should export getGitDir function', () => {
+    expect(typeof getGitDir).toBe('function')
+  })
+
+  test('should return git directory path when in a git repo', async () => {
+    // This test is run from within the gh-please repo
+    const gitDir = await getGitDir()
+    expect(gitDir).not.toBeNull()
+    expect(gitDir).toContain('.git')
   })
 })
 


### PR DESCRIPTION
## Summary

When running `gh please issue develop --worktree` inside a cloned repository (without `--repo` flag), now uses the current repo's gitDir instead of requiring a bare repo clone.

## Changes

- Add `createWorktreeFromRepo()` for non-bare repo worktree creation
- Add `getGitDir()` to detect current repo's git directory  
- Update `fetchBranch()` with proper remote tracking refs
- Extend `RepositoryInfo` type with optional `gitDir` field
- Update develop command to use gitDir when available

## Benefits

- Eliminates redundant bare repo clones when already in a repo
- Ensures proper remote tracking for fetch operations in worktrees
- Maintains bare repo mode for `--repo` flag usage

## Test Plan

- [ ] Test `gh please issue develop 123 --worktree` inside a cloned repo
- [ ] Test `gh please issue develop 123 --worktree --repo owner/repo` outside a repo
- [ ] Verify worktree has proper remote tracking (`git fetch` works)
- [ ] Unit tests pass: `bun test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Worktrees created inside a cloned repo now use the current repo’s .git directory, avoiding a bare clone and setting correct remote tracking. Using --repo still uses bare repo mode.

- **New Features**
  - Added createWorktreeFromRepo() for non-bare worktree creation.
  - Added getGitDir() to detect the current repo’s git directory.
  - Updated develop command to prefer gitDir when available.
  - Improved fetchBranch() to populate refs/remotes and sync the local branch.

- **Refactors**
  - Split worktree functions into git-workflow-worktree.ts and re-exported from git-workflow.ts.

<sup>Written for commit fed656d7dabc70de19f822f85ea30a92b5da1cef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

