### PR TITLE
chore: orca worktree setup 추가 (orca.yaml + .worktreeinclude)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "language": "english",
   "permissions": {
     "allow": [
       "Bash(bun install)",

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,13 @@
+# .worktreeinclude — worktree로 복사할 gitignored 파일 목록
+# .gitignore 문법 사용. 패턴에 매칭되고 동시에 git이 ignore하는 파일만 복사된다.
+# Claude Code --worktree는 자동 처리. orca/conductor 등 외부 도구는
+#   bunx @pleaseai/worktreeinclude <source> <target> 를 setup 훅에서 실행(orca.yaml 참고).
+# 상세: Skill("standards:dev-tooling") → references/worktree-setup.md
+
+# 루트 환경 변수
+.env
+.env.local
+.env.*.local
+
+# Claude Code 로컬 설정 (공유 설정 심볼릭 링크 — .git/info/exclude로 gitignored)
+.claude/settings.local.json

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,8 @@ export default antfu({
     'CLAUDE.md',
     'docs-dev/**/*.md',
     'docs/**/*.md',
+    // Ignore planning and memory documents with illustrative code blocks
+    '.please/**/*.md',
   ],
 }, {
   rules: {

--- a/orca.yaml
+++ b/orca.yaml
@@ -1,0 +1,18 @@
+# orca.yaml — Orca worktree 생성 시 실행되는 setup 스크립트
+# 사용법: 프로젝트 루트에 두면 Orca가 worktree 생성 시 자동 실행한다(committed 파일이라 팀 공유).
+# 상세: Skill("standards:dev-tooling") → references/worktree-setup.md
+#
+# 환경 변수:
+#   $ORCA_ROOT_PATH     — 메인 체크아웃(루트 저장소) 경로 (복사 원본)
+#   $ORCA_WORKTREE_PATH — 새로 생성된 worktree 경로 (복사 대상)
+#
+# 이 저장소는 mise.toml이 없고 bun이 시스템 PATH에 있는 단일 패키지(Bun 런타임) 프로젝트라
+# mise 미사용 변형을 사용한다: 로컬 파일 복사 → 의존성 설치.
+
+scripts:
+  setup: |
+    set -e
+    # 1. gitignored 로컬 파일(.env*, .claude/settings.local.json)을 메인 체크아웃에서 worktree로 복사.
+    bunx @pleaseai/worktreeinclude "$ORCA_ROOT_PATH" "$ORCA_WORKTREE_PATH"
+    # 2. worktree 안에서 의존성 설치.
+    bun install

--- a/orca.yaml
+++ b/orca.yaml
@@ -14,5 +14,5 @@ scripts:
     set -e
     # 1. gitignored 로컬 파일(.env*, .claude/settings.local.json)을 메인 체크아웃에서 worktree로 복사.
     bunx @pleaseai/worktreeinclude "$ORCA_ROOT_PATH" "$ORCA_WORKTREE_PATH"
-    # 2. worktree 안에서 의존성 설치.
-    bun install
+    # 2. worktree 안에서 의존성 설치 (--frozen-lockfile로 lockfile 변경 방지 → worktree가 dirty state로 시작하지 않음).
+    bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

Add Orca worktree configuration files to support isolated worktree-based development workflows.

## Changes

- **orca.yaml**: Orca worktree setup hook using the mise-free variant. Uses `bunx @pleaseai/worktreeinclude` followed by `bun install` directly, since this is a single-package repo with bun on PATH (no mise task runner needed).
- **.worktreeinclude**: Declares gitignored files that should be copied into each new worktree. Lists `.env*` and `.claude/settings.local.json` so worktrees inherit local environment and Claude Code settings without polluting tracked history.

## Rationale

This repo does not use mise (no `mise.toml`), so the standard `templates/orca.yaml` (which calls mise tasks) does not apply. The non-mise variant calls `bunx`/`bun install` directly, which is appropriate for a bun-native single-package repository.

## Test Plan

- [ ] Verify `orca.yaml` is valid YAML and readable by the Orca CLI
- [ ] Verify `.worktreeinclude` correctly lists paths to copy into new worktrees
- [ ] Create a test worktree and confirm `.env*` and `.claude/settings.local.json` are present

## Notes

- `.claude/settings.local.json` is gitignored via `.git/info/exclude` (not `.gitignore`), which is why it must be listed in `.worktreeinclude` for worktree copying.
- No source code or behavior changes — tooling config only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `orca.yaml` and `.worktreeinclude` to auto-copy local config into new worktrees and install dependencies with Bun, using a frozen lockfile to keep worktrees clean. Also ignore `.please/**/*.md` in ESLint to unbreak lint checks and set Claude output language to English.

<sup>Written for commit ca35e03fbf5e9350de957199deba66e638dc559a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Orca worktree setup configuration that prepares new worktrees, copies eligible gitignored local files over, and then installs dependencies.
  * Introduced a `.worktreeinclude` file to define which ignored local files are eligible for inclusion, including root `.env` variants and local Claude settings.
* **Documentation**
  * Documented how `.gitignore`-style patterns are used to determine which files get copied into worktrees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->