### PR TITLE
feat(auth): GitHub App installation token을 지원하는 auth login 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 @docs-dev/GH_FIELDS_MAINTENANCE.md
 @docs-dev/ISSUE_WORKFLOW.md
 @docs-dev/PR_REVIEW_WORKFLOW.md
+@docs-dev/AUTH_WORKFLOW.md
 
 ## Project Overview
 
@@ -184,6 +185,13 @@ gh please pr review reply <comment-id> -b "text"  # Reply to review comment (sup
 gh please pr review thread list <pr-number> [--unresolved-only]          # List review threads with Node IDs
 gh please pr review thread resolve <pr-number> [--thread <id> | --all]   # Resolve threads
 gh please pr review comment edit <comment-id> --body "text" [--pr <number>]  # Edit PR review comment (supports both ID formats)
+
+# Authentication (Built-in) - mirrors `gh auth`, adds GitHub App installation tokens (see @docs-dev/AUTH_WORKFLOW.md)
+gh please auth login                                # Mirror `gh auth login` (interactive / --with-token / --web)
+gh please auth login --app-id <id> --private-key <path> [--installation-id <id> | --owner <org/user>] [--print-token] [--setup-git]  # GitHub App installation token
+gh please auth token                               # Re-mint fresh App token from saved config (else mirror `gh auth token`)
+gh please auth git-credential <get|store|erase>    # git credential helper with auto-refreshing App tokens
+gh please auth <status|logout|refresh|...>         # Passthrough to gh CLI
 
 # Deprecated (still works with warning)
 gh please review-reply <comment-id> -b "text"      # → Use 'gh please pr review reply'
@@ -573,6 +581,7 @@ See dedicated workflow documentation:
 
 - **Issue Development**: @docs-dev/ISSUE_WORKFLOW.md
 - **PR Review**: @docs-dev/PR_REVIEW_WORKFLOW.md
+- **Authentication (GitHub App tokens)**: @docs-dev/AUTH_WORKFLOW.md
 - **GitHub ID Systems**: @docs-dev/GITHUB_ID_SYSTEMS.md
 - **gh CLI Passthrough**: @docs-dev/GH_CLI_PASSTHROUGH.md
 

--- a/docs-dev/AUTH_WORKFLOW.md
+++ b/docs-dev/AUTH_WORKFLOW.md
@@ -1,0 +1,137 @@
+# Authentication Workflow
+
+`gh please auth` mirrors `gh auth` and adds **GitHub App installation token**
+support, including re-mint and transparent git auto-refresh.
+
+See `docs-dev/adr/0008-auth-github-app-installation-tokens.md` for the design
+rationale.
+
+## Mirroring `gh auth login`
+
+With no App flags, `gh please auth login` behaves exactly like `gh auth login`
+(interactive browser flow, `--with-token`, `--web`, etc.). All other `auth`
+subcommands (`status`, `logout`, `refresh`, `setup-git`) pass through to `gh`.
+
+```bash
+gh please auth login                 # interactive, same as gh auth login
+gh please auth login --web
+gh please auth login --with-token < mytoken.txt
+gh please auth status
+```
+
+## GitHub App installation tokens
+
+GitHub App installation tokens are scoped, short-lived (~1 hour) credentials
+ideal for CI and automation. You need:
+
+- **App ID** (or Client ID)
+- **Private key** (`.pem`) generated for the App
+- A target **installation** (the org/user where the App is installed)
+
+### One-time login (store in gh)
+
+```bash
+# Explicit installation
+gh please auth login --app-id 123456 \
+  --private-key ./app.private-key.pem \
+  --installation-id 789
+
+# Auto-resolve installation from an org/user
+gh please auth login --app-id 123456 \
+  --private-key ./app.private-key.pem \
+  --owner pleaseai
+
+# Auto-select when the App has exactly one installation
+gh please auth login --app-id 123456 \
+  --private-key ./app.private-key.pem
+```
+
+This mints a token, stores it via `gh auth login --with-token`, and saves the
+App config to `~/.please/auth.json` (so it can be re-minted later). The private
+key value is **never** stored — only a path reference.
+
+### Private key sources
+
+| Source | How |
+|--------|-----|
+| File | `--private-key ./app.pem` |
+| Stdin | `--private-key -` (e.g. `cat app.pem \| gh please auth login … --private-key -`) |
+| Env var | set `GH_APP_PRIVATE_KEY` to the PEM contents, omit `--private-key` |
+
+> Note: a key supplied via stdin is one-shot and cannot be auto-refreshed (no
+> path to re-read), so config is not persisted in that case.
+
+### Print the token (CI)
+
+Use `--print-token` to emit the raw token to stdout instead of storing it:
+
+```bash
+export GH_TOKEN=$(gh please auth login --app-id 123456 \
+  --private-key ./app.pem --installation-id 789 --print-token)
+```
+
+## Token auto-refresh (re-mint)
+
+Installation tokens expire after ~1 hour and **cannot be OAuth-refreshed** — they
+must be re-minted from the App credentials. After a one-time login, two paths
+keep you fresh:
+
+### 1. `gh please auth token` — re-mint on demand
+
+```bash
+# Always returns a valid token, freshly minted from saved App config
+export GH_TOKEN=$(gh please auth token)
+```
+
+If no App config is saved, this mirrors native `gh auth token`.
+
+### 2. git credential helper — transparent refresh for git
+
+Configure once (or pass `--setup-git` during login):
+
+```bash
+git config --global credential.https://github.com.helper '!gh-please auth git-credential'
+# or:
+gh please auth login --app-id 123456 --private-key ./app.pem --owner pleaseai --setup-git
+```
+
+Now `git push` / `git fetch` mint a fresh installation token automatically on
+every operation — no expiry to manage, no daemon.
+
+## GitHub Enterprise Server
+
+Pass `--hostname` to target a GHES instance (API base becomes
+`https://<host>/api/v3`):
+
+```bash
+gh please auth login --app-id 123456 --private-key ./app.pem \
+  --owner my-org --hostname github.example.com
+```
+
+## How it works
+
+```
+--private-key ──▶ resolvePrivateKey ──▶ generateAppJwt (RS256, node:crypto)
+                                              │
+                          ┌───────────────────┴───────────────────┐
+                          ▼                                        ▼
+              resolveInstallationId                    createInstallationToken
+        (--installation-id / --owner / auto)     POST /app/installations/{id}/access_tokens
+                          │                                        │
+                          └──────────────┬─────────────────────────┘
+                                         ▼
+                    store via gh --with-token   OR   --print-token (stdout)
+                                         │
+                          persist ~/.please/auth.json (0600, no secret)
+                                         │
+                          re-mint:  auth token  /  auth git-credential
+```
+
+## Security notes
+
+- The App private key value is never written to disk by gh-please; only a path
+  reference is stored in `~/.please/auth.json` (mode `0600`).
+- Tokens are short-lived by design; prefer re-mint (`auth token` / git helper)
+  over long-term storage.
+- Treat printed tokens like passwords — they grant the App installation's
+  permissions until expiry.

--- a/docs-dev/AUTH_WORKFLOW.md
+++ b/docs-dev/AUTH_WORKFLOW.md
@@ -10,7 +10,8 @@ rationale.
 
 With no App flags, `gh please auth login` behaves exactly like `gh auth login`
 (interactive browser flow, `--with-token`, `--web`, etc.). All other `auth`
-subcommands (`status`, `logout`, `refresh`, `setup-git`) pass through to `gh`.
+subcommands (`status`, `logout`, `refresh`) pass through to `gh`. (`--setup-git`
+is a flag on `gh please auth login`, not a standalone subcommand.)
 
 ```bash
 gh please auth login                 # interactive, same as gh auth login
@@ -110,7 +111,7 @@ gh please auth login --app-id 123456 --private-key ./app.pem \
 
 ## How it works
 
-```
+```text
 --private-key ──▶ resolvePrivateKey ──▶ generateAppJwt (RS256, node:crypto)
                                               │
                           ┌───────────────────┴───────────────────┐

--- a/docs-dev/adr/0008-auth-github-app-installation-tokens.md
+++ b/docs-dev/adr/0008-auth-github-app-installation-tokens.md
@@ -1,0 +1,134 @@
+# ADR 0008: `auth login` with GitHub App Installation Token Support
+
+**Status**: Proposed
+**Date**: 2026-06-25
+**Author**: Development Team
+
+## Context
+
+`gh please` passes `auth` commands through to the native `gh` CLI today, so
+`gh please auth login` already behaves like `gh auth login` (browser flow,
+`--with-token`, etc.). However, the native `gh auth login` only supports
+**user** authentication (OAuth or a personal access token). It has **no support
+for authenticating as a GitHub App installation**.
+
+GitHub App installation tokens are the recommended credential for automation
+(CI, bots, server-to-server) because they are:
+
+1. **Scoped** to a single installation (one org/user account) and its granted
+   permissions
+2. **Short-lived** (~1 hour), reducing blast radius if leaked
+3. **Auditable** as the App rather than a human user
+
+The gap: there is no first-class CLI path to mint an installation token and feed
+it into the `gh` credential store, and—because the token expires hourly—no
+ergonomic way to keep it fresh.
+
+Minting an installation token requires:
+
+1. Signing a short-lived **RS256 JWT** with the App's private key (`iss` = App
+   ID, `exp` ≤ 10 min)
+2. Resolving the target **installation ID** (directly, by owner, or
+   auto-selected when the App has a single installation)
+3. Exchanging the JWT at `POST /app/installations/{id}/access_tokens`
+
+## Decision
+
+Register an explicit `auth` command group that **mirrors `gh auth login`** for
+all standard flows and **adds a GitHub App installation-token mode**. Since the
+tokens are short-lived, also provide **re-mint** primitives so callers can always
+obtain a valid token without an OAuth-style refresh.
+
+### Command surface
+
+| Command | Behavior |
+|---------|----------|
+| `gh please auth login` (no App flags) | Mirror `gh auth login` exactly (stdio inherited for interactive flows) |
+| `gh please auth login --app-id … --private-key …` | Mint an installation token; store via `gh auth login --with-token` (or `--print-token`); persist App config for re-mint |
+| `gh please auth token` | Re-mint a fresh token from saved App config (else mirror `gh auth token`) |
+| `gh please auth git-credential <op>` | git credential helper that mints a fresh token per `get` (transparent auto-refresh) |
+| `gh please auth <other>` | Passthrough to `gh auth <other>` (status, logout, refresh, …) |
+
+### Key design choices
+
+1. **Mirror by raw forwarding, not re-parsing.** When no `--app-id` is present,
+   the original `process.argv` tail is forwarded verbatim to `gh auth login`
+   with inherited stdio. This guarantees 100% fidelity with the native command
+   (including flags we never declared) and preserves interactive TTY prompts.
+
+2. **No new runtime dependency for crypto.** The RS256 JWT is signed with Bun's
+   built-in `node:crypto` (`createSign('RSA-SHA256')`). No `jsonwebtoken` or
+   similar dependency is added.
+
+3. **Token delivery is store-by-default, print-on-demand.** The default pipes the
+   token to `gh auth login --with-token` so the whole `gh`/`gh please` toolchain
+   uses it. `--print-token` emits the raw token to stdout for CI
+   (`export GH_TOKEN=$(gh please auth login … --print-token)`).
+
+4. **"Auto-refresh" = re-mint, not OAuth refresh.** Installation tokens cannot be
+   refreshed; they must be regenerated from the App credentials. We persist the
+   App config (App ID, resolved installation ID, hostname, and a **path
+   reference** to the private key) to `~/.please/auth.json` and re-mint on demand:
+   - `gh please auth token` for explicit/CI re-mint
+   - `gh please auth git-credential` as a git credential helper, giving
+     transparent per-operation refresh for `git push`/`fetch` without a daemon.
+
+5. **Secrets are never persisted.** `auth.json` stores only a `privateKeyPath`
+   reference (or relies on the `GH_APP_PRIVATE_KEY` env var); the PEM contents are
+   never written to disk by gh-please. The file is created with `0600`
+   permissions. When the key was supplied via stdin (`--private-key -`), no
+   config is persisted because there is nothing safe to reference for re-mint.
+
+6. **Installation resolution is layered.** Explicit `--installation-id` wins;
+   otherwise `--owner` looks up `/orgs/{owner}/installation` then
+   `/users/{owner}/installation`; otherwise the single installation is
+   auto-selected, and ambiguity is reported with the candidate list.
+
+### Private key sources (precedence)
+
+1. `--private-key -` → read PEM from stdin
+2. `--private-key <path>` → read PEM from file
+3. `GH_APP_PRIVATE_KEY` env var → PEM contents
+
+## Alternatives Considered
+
+- **Pure passthrough only (do nothing).** Rejected: `gh` cannot mint App tokens,
+  which is the entire point of the request.
+- **Store credentials and run a background refresh daemon.** Rejected for v1: a
+  long-running process is fragile for a CLI; the git credential helper provides
+  transparent refresh without one. Can be added later behind a `--watch` flag.
+- **Add a JWT library dependency.** Rejected: `node:crypto` covers RS256 signing
+  with zero new dependencies and a smaller bundle.
+- **Use `gh api` for the JWT-authenticated calls.** Rejected: `gh api` injects the
+  stored user token, not our App JWT. We call the REST API directly via `fetch`
+  with the JWT as a Bearer token.
+
+## Consequences
+
+**Positive**
+- First-class GitHub App auth that integrates with the existing `gh` credential
+  store and the whole `gh please` toolchain.
+- True transparent auto-refresh for git operations with no daemon.
+- No new dependencies; works on GitHub.com and GitHub Enterprise Server.
+
+**Negative / Trade-offs**
+- `gh please auth token` is context-dependent (App re-mint vs. native mirror),
+  which is slightly less predictable than a single behavior.
+- Re-mint requires the private key to remain available at the recorded path or
+  env var; stdin-supplied keys are one-shot and not auto-refreshable.
+
+## Implementation
+
+- `src/lib/github-app.ts` — JWT signing, installation resolution, token exchange,
+  private key resolution
+- `src/lib/auth-config.ts` — `~/.please/auth.json` read/write (`0600`, no secrets)
+- `src/lib/app-auth.ts` — re-mint orchestration from saved config
+- `src/commands/auth/{index,login,token,git-credential}.ts` — command surface
+- Tests: `test/lib/github-app.test.ts`, `test/lib/auth-config.test.ts`,
+  `test/commands/auth/*`
+
+## Related
+
+- ADR 0007 — gh CLI Passthrough (auth subcommands fall through to `gh`)
+- `docs-dev/AUTH_WORKFLOW.md` — usage workflow
+- [GitHub docs: Authenticating as a GitHub App installation](https://docs.github.com/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation)

--- a/src/commands/auth/git-credential.ts
+++ b/src/commands/auth/git-credential.ts
@@ -1,20 +1,57 @@
 import { Command } from 'commander'
-import { mintTokenFromSavedConfig } from '../../lib/app-auth'
+import { mintTokenFromConfig } from '../../lib/app-auth'
+import { readAuthConfig } from '../../lib/auth-config'
 import { detectSystemLanguage, getAuthMessages } from '../../lib/i18n'
 
 /** GitHub App installation token의 git 사용자명 (고정값) */
 const APP_TOKEN_USERNAME = 'x-access-token'
 
 /**
+ * git credential 프로토콜 입력(key=value 줄)을 파싱한다.
+ */
+export function parseCredentialInput(input: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const line of input.split('\n')) {
+    const eq = line.indexOf('=')
+    if (eq === -1) {
+      continue
+    }
+    const key = line.slice(0, eq)
+    if (key) {
+      result[key] = line.slice(eq + 1)
+    }
+  }
+  return result
+}
+
+/**
  * git credential helper의 `get` 동작을 처리한다.
- * 저장된 설정으로 새 토큰을 발급해 git credential 프로토콜 형식으로 인쇄한다.
+ * 요청한 host/protocol이 저장된 설정과 일치할 때만 새 토큰을 발급해 인쇄한다.
  * 매 호출마다 새로 발급하므로 git 작업 시 토큰이 투명하게 자동 갱신된다.
  */
 async function handleGet(): Promise<void> {
-  // git이 stdin으로 보낸 속성을 소비한다 (값은 사용하지 않음)
-  await new Response(Bun.stdin.stream()).text()
+  const input = await new Response(Bun.stdin.stream()).text()
+  const request = parseCredentialInput(input)
 
-  const { token } = await mintTokenFromSavedConfig()
+  const config = readAuthConfig()
+  if (!config) {
+    throw new Error(
+      'No saved GitHub App credentials found. Run `gh please auth login --app-id <id> --private-key <path>` first.',
+    )
+  }
+
+  // 저장된 호스트(또는 github.com)와 https가 아닌 요청에는 토큰을 제공하지 않는다.
+  // 아무것도 출력하지 않으면 git이 다음 credential helper로 넘어간다 → App 토큰이
+  // 무관한 호스트로 새어 나가는 것을 방지한다.
+  const expectedHost = config.hostname || 'github.com'
+  if (request.protocol && request.protocol !== 'https') {
+    return
+  }
+  if (request.host && request.host !== expectedHost) {
+    return
+  }
+
+  const { token } = await mintTokenFromConfig(config)
   process.stdout.write(`username=${APP_TOKEN_USERNAME}\npassword=${token}\n`)
 }
 

--- a/src/commands/auth/git-credential.ts
+++ b/src/commands/auth/git-credential.ts
@@ -1,0 +1,50 @@
+import { Command } from 'commander'
+import { mintTokenFromSavedConfig } from '../../lib/app-auth'
+import { detectSystemLanguage, getAuthMessages } from '../../lib/i18n'
+
+/** GitHub App installation token의 git 사용자명 (고정값) */
+const APP_TOKEN_USERNAME = 'x-access-token'
+
+/**
+ * git credential helper의 `get` 동작을 처리한다.
+ * 저장된 설정으로 새 토큰을 발급해 git credential 프로토콜 형식으로 인쇄한다.
+ * 매 호출마다 새로 발급하므로 git 작업 시 토큰이 투명하게 자동 갱신된다.
+ */
+async function handleGet(): Promise<void> {
+  // git이 stdin으로 보낸 속성을 소비한다 (값은 사용하지 않음)
+  await new Response(Bun.stdin.stream()).text()
+
+  const { token } = await mintTokenFromSavedConfig()
+  process.stdout.write(`username=${APP_TOKEN_USERNAME}\npassword=${token}\n`)
+}
+
+/**
+ * `gh please auth git-credential <operation>` 명령을 생성한다.
+ * git credential helper 프로토콜을 구현한다. `!gh-please auth git-credential` 형태로
+ * git에 등록하면 git이 자격 증명이 필요할 때마다 새 토큰을 발급받는다.
+ */
+export function createGitCredentialCommand(): Command {
+  const command = new Command('git-credential')
+    .description('git credential helper providing auto-refreshing GitHub App tokens')
+    .argument('<operation>', 'git credential operation: get, store, or erase')
+    .action(async (operation: string) => {
+      const lang = detectSystemLanguage()
+      const msg = getAuthMessages(lang)
+
+      // store/erase는 매번 재발급하므로 영속화할 것이 없다. stdin을 소비하고 종료한다.
+      if (operation !== 'get') {
+        await new Response(Bun.stdin.stream()).text()
+        return
+      }
+
+      try {
+        await handleGet()
+      }
+      catch (error) {
+        console.error(`${msg.errorPrefix}: ${error instanceof Error ? error.message : msg.unknownError}`)
+        process.exit(1)
+      }
+    })
+
+  return command
+}

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -1,0 +1,30 @@
+import { Command } from 'commander'
+import { passThroughCommand } from '../../lib/gh-passthrough'
+import { createGitCredentialCommand } from './git-credential'
+import { createAuthLoginCommand } from './login'
+import { createAuthTokenCommand } from './token'
+
+/**
+ * `gh please auth` 명령 그룹을 생성한다.
+ * `gh auth`를 미러링하며, GitHub App installation token 발급/재발급과
+ * git credential helper 기능을 추가한다. 등록되지 않은 하위 명령
+ * (status, logout, refresh, setup-git 등)은 gh CLI로 패스스루한다.
+ */
+export function createAuthCommand(): Command {
+  const command = new Command('auth')
+
+  command.description('Authenticate gh and gh please with GitHub (supports GitHub App installation tokens)')
+
+  command.addCommand(createAuthLoginCommand())
+  command.addCommand(createAuthTokenCommand())
+  command.addCommand(createGitCredentialCommand())
+
+  // 등록되지 않은 하위 명령은 gh CLI로 패스스루
+  command.allowUnknownOption()
+  command.on('command:*', async (_operands) => {
+    const subArgs = command.args.length > 0 ? command.args : process.argv.slice(3)
+    await passThroughCommand(['auth', ...subArgs])
+  })
+
+  return command
+}

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,5 +1,6 @@
 import type { AuthMessages } from '../../lib/i18n'
 import type { AppLoginOptions, AuthConfig } from '../../types'
+import { resolve } from 'node:path'
 import { Command } from 'commander'
 import { writeAuthConfig } from '../../lib/auth-config'
 import { createInstallationToken, generateAppJwt, resolveInstallationId, resolvePrivateKey } from '../../lib/github-app'
@@ -38,7 +39,7 @@ async function storeTokenInGh(token: string, hostname?: string): Promise<void> {
   }
   const proc = Bun.spawn([getGhCommand(), ...args], {
     stdin: 'pipe',
-    stdout: 'pipe',
+    stdout: 'ignore',
     stderr: 'pipe',
   })
   proc.stdin.write(token)
@@ -62,7 +63,7 @@ async function setupGitHelper(hostname?: string): Promise<void> {
   const host = hostname || 'github.com'
   const proc = Bun.spawn(
     ['git', 'config', '--global', `credential.https://${host}.helper`, '!gh-please auth git-credential'],
-    { stdout: 'pipe', stderr: 'pipe' },
+    { stdout: 'ignore', stderr: 'pipe' },
   )
   const exitCode = await proc.exited
   if (exitCode !== 0) {
@@ -90,9 +91,15 @@ async function runAppLogin(options: AppLoginOptions, msg: AuthMessages): Promise
   console.error(msg.mintingToken)
   const { token, expiresAt } = await createInstallationToken({ jwt, installationId, hostname: options.hostname })
 
-  // 재발급(자동 갱신) 가능하도록 설정을 저장한다. private key 경로일 때만 영속화 가능.
-  if (options.privateKey && options.privateKey !== '-') {
-    const config: AuthConfig = { appId, installationId, privateKeyPath: options.privateKey }
+  // 재발급(자동 갱신) 가능하도록 설정을 저장한다. stdin 키는 일회성이라 재발급이
+  // 불가하므로 그 경우만 저장을 건너뛴다. 파일 경로가 주어지면 절대 경로로 변환해
+  // (다른 CWD에서 재발급 시 ENOENT 방지) 저장하고, 경로가 없으면(GH_APP_PRIVATE_KEY
+  // 환경 변수 사용) 경로 없이 저장해 재발급 시 동일 환경 변수를 사용하도록 한다.
+  if (options.privateKey !== '-') {
+    const config: AuthConfig = { appId, installationId }
+    if (options.privateKey) {
+      config.privateKeyPath = resolve(options.privateKey)
+    }
     if (options.hostname) {
       config.hostname = options.hostname
     }
@@ -138,6 +145,21 @@ export function createAuthLoginCommand(): Command {
       const msg = getAuthMessages(lang)
 
       if (!options.appId) {
+        // App 전용 플래그를 --app-id 없이 쓰면 gh auth login으로 그대로 넘어가
+        // 불명확한 "unknown flag" 오류가 난다. 미리 명확한 안내를 준다.
+        const appOnlyFlags: Array<[keyof AppLoginOptions, string]> = [
+          ['privateKey', '--private-key'],
+          ['installationId', '--installation-id'],
+          ['owner', '--owner'],
+          ['printToken', '--print-token'],
+          ['setupGit', '--setup-git'],
+        ]
+        const misused = appOnlyFlags.filter(([key]) => options[key]).map(([, flag]) => flag)
+        if (misused.length > 0) {
+          console.error(`${msg.errorPrefix}: ${msg.appFlagsRequireAppId(misused.join(', '))}`)
+          process.exit(1)
+        }
+
         await mirrorGhAuthLogin()
         return
       }

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,0 +1,155 @@
+import type { AuthMessages } from '../../lib/i18n'
+import type { AppLoginOptions, AuthConfig } from '../../types'
+import { Command } from 'commander'
+import { writeAuthConfig } from '../../lib/auth-config'
+import { createInstallationToken, generateAppJwt, resolveInstallationId, resolvePrivateKey } from '../../lib/github-app'
+import { detectSystemLanguage, getAuthMessages } from '../../lib/i18n'
+
+/** 테스트에서 gh 명령을 주입할 수 있도록 환경 변수 또는 기본값을 사용한다 */
+function getGhCommand(): string {
+  return process.env.GH_PATH || 'gh'
+}
+
+/**
+ * 표준 `gh auth login` 동작을 그대로 미러링한다 (대화형 브라우저/토큰 플로우).
+ * stdio를 상속해 TTY 기반 프롬프트가 정상 동작하도록 한다.
+ */
+async function mirrorGhAuthLogin(): Promise<never> {
+  const argv = process.argv
+  const idx = argv.indexOf('auth')
+  const args = idx >= 0 ? argv.slice(idx) : ['auth', 'login']
+
+  const proc = Bun.spawn([getGhCommand(), ...args], {
+    stdin: 'inherit',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  const exitCode = await proc.exited
+  process.exit(exitCode)
+}
+
+/**
+ * 발급한 토큰을 `gh auth login --with-token`으로 파이프해 gh 자격 증명 저장소에 저장한다.
+ */
+async function storeTokenInGh(token: string, hostname?: string): Promise<void> {
+  const args = ['auth', 'login', '--with-token']
+  if (hostname) {
+    args.push('--hostname', hostname)
+  }
+  const proc = Bun.spawn([getGhCommand(), ...args], {
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  proc.stdin.write(token)
+  await proc.stdin.end()
+
+  const exitCode = await proc.exited
+  if (exitCode !== 0) {
+    const error = await new Response(proc.stderr).text()
+    throw new Error(`gh auth login --with-token failed: ${error.trim()}`)
+  }
+}
+
+/** git credential helper 등록용 git config 명령 문자열을 만든다 */
+export function buildGitHelperCommand(hostname?: string): string {
+  const host = hostname || 'github.com'
+  return `git config --global credential.https://${host}.helper '!gh-please auth git-credential'`
+}
+
+/** git credential helper를 전역 git 설정에 등록한다 */
+async function setupGitHelper(hostname?: string): Promise<void> {
+  const host = hostname || 'github.com'
+  const proc = Bun.spawn(
+    ['git', 'config', '--global', `credential.https://${host}.helper`, '!gh-please auth git-credential'],
+    { stdout: 'pipe', stderr: 'pipe' },
+  )
+  const exitCode = await proc.exited
+  if (exitCode !== 0) {
+    const error = await new Response(proc.stderr).text()
+    throw new Error(`Failed to configure git credential helper: ${error.trim()}`)
+  }
+}
+
+/**
+ * GitHub App installation token 플로우를 실행한다.
+ * private key로 JWT를 만들고 installation token을 발급한 뒤, 저장 또는 인쇄한다.
+ * 재발급을 위해 App 설정(비밀 값 제외)을 영속화한다.
+ */
+async function runAppLogin(options: AppLoginOptions, msg: AuthMessages): Promise<void> {
+  const privateKey = await resolvePrivateKey({ path: options.privateKey })
+  const appId = options.appId!
+  const jwt = generateAppJwt({ appId, privateKey })
+
+  let installationId = options.installationId
+  if (!installationId) {
+    console.error(msg.resolvingInstallation)
+    installationId = await resolveInstallationId({ jwt, owner: options.owner, hostname: options.hostname })
+  }
+
+  console.error(msg.mintingToken)
+  const { token, expiresAt } = await createInstallationToken({ jwt, installationId, hostname: options.hostname })
+
+  // 재발급(자동 갱신) 가능하도록 설정을 저장한다. private key 경로일 때만 영속화 가능.
+  if (options.privateKey && options.privateKey !== '-') {
+    const config: AuthConfig = { appId, installationId, privateKeyPath: options.privateKey }
+    if (options.hostname) {
+      config.hostname = options.hostname
+    }
+    writeAuthConfig(config)
+  }
+
+  if (options.printToken) {
+    process.stdout.write(token)
+    console.error(msg.tokenExpiresAt(expiresAt))
+    return
+  }
+
+  await storeTokenInGh(token, options.hostname)
+  console.log(msg.appLoginSuccess(installationId, expiresAt))
+
+  if (options.setupGit) {
+    await setupGitHelper(options.hostname)
+    console.log(msg.gitHelperConfigured(options.hostname || 'github.com'))
+  }
+  else {
+    console.log(msg.gitHelperHint(buildGitHelperCommand(options.hostname)))
+  }
+}
+
+/**
+ * `gh please auth login` 명령을 생성한다.
+ * App 플래그가 없으면 `gh auth login`을 미러링하고, 있으면 installation token 플로우를 실행한다.
+ */
+export function createAuthLoginCommand(): Command {
+  const command = new Command('login')
+    .description('Authenticate with GitHub (mirrors `gh auth login`, adds GitHub App installation token support)')
+    .option('--app-id <id>', 'GitHub App ID or Client ID (enables App installation token mode)')
+    .option('--private-key <path>', 'Path to App private key PEM (use \'-\' for stdin, or set GH_APP_PRIVATE_KEY)')
+    .option('--installation-id <id>', 'Target installation ID')
+    .option('--owner <owner>', 'Org or user to auto-resolve the installation from')
+    .option('--hostname <host>', 'GitHub hostname (for GitHub Enterprise Server)')
+    .option('--print-token', 'Print the installation token to stdout instead of storing it')
+    .option('--setup-git', 'Configure git credential helper for transparent token auto-refresh')
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .action(async (options: AppLoginOptions) => {
+      const lang = detectSystemLanguage()
+      const msg = getAuthMessages(lang)
+
+      if (!options.appId) {
+        await mirrorGhAuthLogin()
+        return
+      }
+
+      try {
+        await runAppLogin(options, msg)
+      }
+      catch (error) {
+        console.error(`${msg.errorPrefix}: ${error instanceof Error ? error.message : msg.unknownError}`)
+        process.exit(1)
+      }
+    })
+
+  return command
+}

--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -1,0 +1,56 @@
+import { Command } from 'commander'
+import { mintTokenFromConfig } from '../../lib/app-auth'
+import { readAuthConfig } from '../../lib/auth-config'
+import { executeGhCommand } from '../../lib/gh-passthrough'
+import { detectSystemLanguage, getAuthMessages } from '../../lib/i18n'
+
+/**
+ * 저장된 App 설정이 없을 때 네이티브 `gh auth token`으로 패스스루한다.
+ * 원본 인자(예: --hostname)를 그대로 전달해 미러링 동작을 유지한다.
+ */
+async function mirrorGhAuthToken(): Promise<never> {
+  const argv = process.argv
+  const idx = argv.indexOf('auth')
+  const args = idx >= 0 ? argv.slice(idx) : ['auth', 'token']
+
+  const result = await executeGhCommand(args)
+  if (result.stdout) {
+    process.stdout.write(result.stdout)
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr)
+  }
+  process.exit(result.exitCode)
+}
+
+/**
+ * `gh please auth token` 명령을 생성한다.
+ * 저장된 GitHub App 설정이 있으면 새 installation token을 발급해 표준 출력으로 인쇄하고
+ * (`export GH_TOKEN=$(gh please auth token)`), 없으면 네이티브 `gh auth token`을 미러링한다.
+ */
+export function createAuthTokenCommand(): Command {
+  const command = new Command('token')
+    .description('Mint a fresh GitHub App installation token from saved credentials, or mirror `gh auth token`')
+    .allowUnknownOption()
+    .action(async () => {
+      const lang = detectSystemLanguage()
+      const msg = getAuthMessages(lang)
+
+      const config = readAuthConfig()
+      if (!config) {
+        await mirrorGhAuthToken()
+        return
+      }
+
+      try {
+        const { token } = await mintTokenFromConfig(config)
+        process.stdout.write(token)
+      }
+      catch (error) {
+        console.error(`${msg.errorPrefix}: ${error instanceof Error ? error.message : msg.unknownError}`)
+        process.exit(1)
+      }
+    })
+
+  return command
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander'
 import packageJson from '../package.json' with { type: 'json' }
+import { createAuthCommand } from './commands/auth'
 import { createIssueCommand } from './commands/issue'
 import { createPluginCommand } from './commands/plugin'
 import { createPrCommand } from './commands/pr'
@@ -22,6 +23,7 @@ export async function createProgram(): Promise<Command> {
     .version(packageJson.version)
 
   // Add core command groups
+  program.addCommand(createAuthCommand())
   program.addCommand(createIssueCommand())
   program.addCommand(createPrCommand())
   program.addCommand(createRepoCommand())

--- a/src/lib/app-auth.ts
+++ b/src/lib/app-auth.ts
@@ -1,0 +1,37 @@
+import type { AuthConfig, InstallationTokenResult } from '../types'
+import { readAuthConfig } from './auth-config'
+import { createInstallationToken, generateAppJwt, resolvePrivateKey } from './github-app'
+
+/**
+ * 영속화된 GitHub App 설정으로부터 새 installation token을 발급한다.
+ * installation token은 약 1시간 후 만료되므로, 항상 유효한 토큰이 필요한 경우
+ * 매번 이 함수를 호출해 새로 발급한다 (재발급 기반 자동 갱신).
+ */
+export async function mintTokenFromConfig(
+  config: AuthConfig,
+  env: Record<string, string | undefined> = process.env,
+): Promise<InstallationTokenResult> {
+  const privateKey = await resolvePrivateKey({ path: config.privateKeyPath, env })
+  const jwt = generateAppJwt({ appId: config.appId, privateKey })
+  return createInstallationToken({
+    jwt,
+    installationId: config.installationId,
+    hostname: config.hostname,
+  })
+}
+
+/**
+ * 저장된 설정을 읽어 새 installation token을 발급한다.
+ * 설정이 없으면 안내 메시지와 함께 오류를 던진다.
+ */
+export async function mintTokenFromSavedConfig(
+  env: Record<string, string | undefined> = process.env,
+): Promise<InstallationTokenResult> {
+  const config = readAuthConfig()
+  if (!config) {
+    throw new Error(
+      'No saved GitHub App credentials found. Run `gh please auth login --app-id <id> --private-key <path>` first.',
+    )
+  }
+  return mintTokenFromConfig(config, env)
+}

--- a/src/lib/app-auth.ts
+++ b/src/lib/app-auth.ts
@@ -1,5 +1,4 @@
 import type { AuthConfig, InstallationTokenResult } from '../types'
-import { readAuthConfig } from './auth-config'
 import { createInstallationToken, generateAppJwt, resolvePrivateKey } from './github-app'
 
 /**
@@ -18,20 +17,4 @@ export async function mintTokenFromConfig(
     installationId: config.installationId,
     hostname: config.hostname,
   })
-}
-
-/**
- * 저장된 설정을 읽어 새 installation token을 발급한다.
- * 설정이 없으면 안내 메시지와 함께 오류를 던진다.
- */
-export async function mintTokenFromSavedConfig(
-  env: Record<string, string | undefined> = process.env,
-): Promise<InstallationTokenResult> {
-  const config = readAuthConfig()
-  if (!config) {
-    throw new Error(
-      'No saved GitHub App credentials found. Run `gh please auth login --app-id <id> --private-key <path>` first.',
-    )
-  }
-  return mintTokenFromConfig(config, env)
 }

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -25,9 +25,10 @@ export function readAuthConfig(path: string = getAuthConfigPath()): AuthConfig |
   try {
     const raw = readFileSync(path, 'utf8')
     const parsed = JSON.parse(raw) as Partial<AuthConfig>
-    // 필수 필드가 문자열인지 검증한다. 손상된 설정(잘못된 타입)은 null로 처리해
-    // 이후 단계에서 런타임 오류가 나는 대신 "손상 => null" 계약을 지킨다.
-    if (typeof parsed.appId !== 'string' || typeof parsed.installationId !== 'string') {
+    // 필수 필드가 비어있지 않은 문자열인지 검증한다. 손상된 설정(잘못된 타입/빈 값)은
+    // null로 처리해 이후 단계에서 런타임 오류가 나는 대신 "손상 => null" 계약을 지킨다.
+    if (typeof parsed.appId !== 'string' || parsed.appId.trim() === ''
+      || typeof parsed.installationId !== 'string' || parsed.installationId.trim() === '') {
       return null
     }
     if (parsed.privateKeyPath !== undefined && typeof parsed.privateKeyPath !== 'string') {

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -1,5 +1,5 @@
 import type { AuthConfig } from '../types'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -25,7 +25,15 @@ export function readAuthConfig(path: string = getAuthConfigPath()): AuthConfig |
   try {
     const raw = readFileSync(path, 'utf8')
     const parsed = JSON.parse(raw) as Partial<AuthConfig>
-    if (!parsed.appId || !parsed.installationId) {
+    // 필수 필드가 문자열인지 검증한다. 손상된 설정(잘못된 타입)은 null로 처리해
+    // 이후 단계에서 런타임 오류가 나는 대신 "손상 => null" 계약을 지킨다.
+    if (typeof parsed.appId !== 'string' || typeof parsed.installationId !== 'string') {
+      return null
+    }
+    if (parsed.privateKeyPath !== undefined && typeof parsed.privateKeyPath !== 'string') {
+      return null
+    }
+    if (parsed.hostname !== undefined && typeof parsed.hostname !== 'string') {
       return null
     }
     return parsed as AuthConfig
@@ -45,4 +53,8 @@ export function writeAuthConfig(config: AuthConfig, path: string = getAuthConfig
     mkdirSync(dir, { recursive: true, mode: 0o700 })
   }
   writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 })
+  // mode 옵션은 파일/디렉터리를 새로 만들 때만 적용된다. 이미 존재하던 경우
+  // 권한이 그대로 남으므로, 매 쓰기마다 명시적으로 0700/0600을 강제한다.
+  chmodSync(dir, 0o700)
+  chmodSync(path, 0o600)
 }

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -1,0 +1,48 @@
+import type { AuthConfig } from '../types'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+/** 설정 디렉터리 (~/.please) */
+function configDir(): string {
+  return join(homedir(), '.please')
+}
+
+/**
+ * GitHub App 인증 설정 파일 경로를 반환한다.
+ */
+export function getAuthConfigPath(): string {
+  return join(configDir(), 'auth.json')
+}
+
+/**
+ * 영속화된 GitHub App 인증 설정을 읽는다. 없거나 손상된 경우 null을 반환한다.
+ */
+export function readAuthConfig(path: string = getAuthConfigPath()): AuthConfig | null {
+  if (!existsSync(path)) {
+    return null
+  }
+  try {
+    const raw = readFileSync(path, 'utf8')
+    const parsed = JSON.parse(raw) as Partial<AuthConfig>
+    if (!parsed.appId || !parsed.installationId) {
+      return null
+    }
+    return parsed as AuthConfig
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * GitHub App 인증 설정을 영속화한다.
+ * 비밀 값(private key)은 저장하지 않으며, 파일은 소유자 전용(0600) 권한으로 기록한다.
+ */
+export function writeAuthConfig(config: AuthConfig, path: string = getAuthConfigPath()): void {
+  const dir = dirname(path)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+  }
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 })
+}

--- a/src/lib/github-app.ts
+++ b/src/lib/github-app.ts
@@ -1,0 +1,221 @@
+import type { InstallationTokenResult, ResolvePrivateKeyOptions } from '../types'
+import { createSign } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+
+/**
+ * GitHub App JWT 만료 시간 (초). GitHub 최대값은 10분이며, 시계 오차를 고려해 9분을 사용한다.
+ */
+const JWT_EXPIRY_SECONDS = 9 * 60
+/**
+ * iat 클럭 드리프트 보정값 (초). 발급 시각을 60초 앞당겨 GitHub 시계와의 오차를 흡수한다.
+ */
+const JWT_CLOCK_DRIFT_SECONDS = 60
+/** 기본 private key 환경 변수 이름 */
+const DEFAULT_PRIVATE_KEY_ENV = 'GH_APP_PRIVATE_KEY'
+
+/**
+ * Base64URL 인코딩 (패딩 없음)
+ */
+function base64url(input: Buffer | string): string {
+  const buf = typeof input === 'string' ? Buffer.from(input) : input
+  return buf.toString('base64url')
+}
+
+/**
+ * GitHub App 인증용 JWT 생성 파라미터
+ */
+export interface AppJwtParams {
+  /** GitHub App ID 또는 Client ID */
+  appId: string
+  /** PEM 형식의 App private key */
+  privateKey: string
+  /** 발급 기준 시각 (Unix 초). 테스트 결정성을 위해 주입 가능 */
+  now?: number
+}
+
+/**
+ * GitHub App private key로 서명한 RS256 JWT를 생성한다.
+ * 이 JWT는 installation access token 발급 등 App 수준 API 호출에 사용된다.
+ */
+export function generateAppJwt(params: AppJwtParams): string {
+  const { appId, privateKey } = params
+  const now = params.now ?? Math.floor(Date.now() / 1000)
+
+  const header = { alg: 'RS256', typ: 'JWT' }
+  const payload = {
+    iat: now - JWT_CLOCK_DRIFT_SECONDS,
+    exp: now + JWT_EXPIRY_SECONDS,
+    iss: appId,
+  }
+
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`
+  const signer = createSign('RSA-SHA256')
+  signer.update(signingInput)
+  signer.end()
+  const signature = signer.sign(privateKey)
+
+  return `${signingInput}.${base64url(signature)}`
+}
+
+/**
+ * 호스트명으로부터 GitHub REST API base URL을 계산한다.
+ * github.com은 api.github.com, GitHub Enterprise Server는 https://<host>/api/v3 형식이다.
+ */
+export function apiBaseUrl(hostname?: string): string {
+  if (!hostname || hostname === 'github.com') {
+    return 'https://api.github.com'
+  }
+  return `https://${hostname}/api/v3`
+}
+
+/**
+ * App JWT로 인증하는 요청의 공통 헤더를 만든다.
+ */
+function appJwtHeaders(jwt: string): Record<string, string> {
+  return {
+    'Authorization': `Bearer ${jwt}`,
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'gh-please',
+  }
+}
+
+/**
+ * installation token 발급 파라미터
+ */
+export interface CreateInstallationTokenParams {
+  jwt: string
+  installationId: string | number
+  hostname?: string
+  /** 테스트용 fetch 주입 (기본: 전역 fetch) */
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * App JWT를 사용해 installation access token을 발급한다.
+ * 발급된 토큰은 약 1시간 후 만료된다.
+ */
+export async function createInstallationToken(
+  params: CreateInstallationTokenParams,
+): Promise<InstallationTokenResult> {
+  const { jwt, installationId, hostname, fetchImpl = fetch } = params
+  const url = `${apiBaseUrl(hostname)}/app/installations/${installationId}/access_tokens`
+
+  const res = await fetchImpl(url, { method: 'POST', headers: appJwtHeaders(jwt) })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Failed to create installation token (HTTP ${res.status}): ${text.trim()}`)
+  }
+
+  const data = await res.json() as { token: string, expires_at: string }
+  return { token: data.token, expiresAt: data.expires_at }
+}
+
+/**
+ * installation 조회 파라미터
+ */
+export interface ResolveInstallationParams {
+  jwt: string
+  /** org 또는 user 이름. 지정 시 해당 소유자의 installation을 조회한다 */
+  owner?: string
+  hostname?: string
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * owner의 installation ID를 조회한다 (org → user 순서로 시도).
+ */
+async function lookupOwnerInstallation(
+  base: string,
+  owner: string,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  for (const path of [`/orgs/${owner}/installation`, `/users/${owner}/installation`]) {
+    const res = await fetchImpl(`${base}${path}`, { headers })
+    if (res.ok) {
+      const data = await res.json() as { id: number }
+      return String(data.id)
+    }
+    if (res.status !== 404) {
+      const text = await res.text()
+      throw new Error(`Failed to look up installation for "${owner}" (HTTP ${res.status}): ${text.trim()}`)
+    }
+  }
+  throw new Error(`No installation found for owner "${owner}"`)
+}
+
+/**
+ * 대상 installation ID를 결정한다.
+ * - owner 지정: 해당 소유자의 installation 조회
+ * - owner 미지정: App의 installation 목록을 조회해 정확히 1개면 자동 선택, 여러 개면 오류
+ */
+export async function resolveInstallationId(params: ResolveInstallationParams): Promise<string> {
+  const { jwt, owner, hostname, fetchImpl = fetch } = params
+  const base = apiBaseUrl(hostname)
+  const headers = appJwtHeaders(jwt)
+
+  if (owner) {
+    return lookupOwnerInstallation(base, owner, headers, fetchImpl)
+  }
+
+  const res = await fetchImpl(`${base}/app/installations`, { headers })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Failed to list installations (HTTP ${res.status}): ${text.trim()}`)
+  }
+
+  const installs = await res.json() as Array<{ id: number, account?: { login?: string } }>
+  if (!Array.isArray(installs) || installs.length === 0) {
+    throw new Error('No installations found for this App')
+  }
+  if (installs.length > 1) {
+    const list = installs.map(i => `  ${i.id} (${i.account?.login ?? 'unknown'})`).join('\n')
+    throw new Error(`Multiple installations found; specify --installation-id or --owner:\n${list}`)
+  }
+  return String(installs[0]!.id)
+}
+
+/**
+ * 표준 입력에서 전체 내용을 읽는다.
+ */
+async function defaultReadStdin(): Promise<string> {
+  return await new Response(Bun.stdin.stream()).text()
+}
+
+/**
+ * private key를 우선순위에 따라 해석한다.
+ * 1. path === '-' : 표준 입력에서 읽기
+ * 2. path 지정    : 파일에서 읽기
+ * 3. 환경 변수    : GH_APP_PRIVATE_KEY (기본)
+ * 비밀 값을 다루므로 어디에서도 로깅하지 않는다.
+ */
+export async function resolvePrivateKey(options: ResolvePrivateKeyOptions = {}): Promise<string> {
+  const {
+    path,
+    envVarName = DEFAULT_PRIVATE_KEY_ENV,
+    env = process.env,
+    readStdin = defaultReadStdin,
+  } = options
+
+  if (path === '-') {
+    const key = (await readStdin()).trim()
+    if (!key) {
+      throw new Error('No private key received on stdin')
+    }
+    return key
+  }
+
+  if (path) {
+    return readFileSync(path, 'utf8')
+  }
+
+  const fromEnv = env[envVarName]
+  if (fromEnv && fromEnv.trim()) {
+    return fromEnv
+  }
+
+  throw new Error(
+    `Private key required: pass --private-key <path>, --private-key - (stdin), or set ${envVarName}`,
+  )
+}

--- a/src/lib/github-app.ts
+++ b/src/lib/github-app.ts
@@ -12,6 +12,13 @@ const JWT_EXPIRY_SECONDS = 9 * 60
 const JWT_CLOCK_DRIFT_SECONDS = 60
 /** 기본 private key 환경 변수 이름 */
 const DEFAULT_PRIVATE_KEY_ENV = 'GH_APP_PRIVATE_KEY'
+/** GitHub API 요청 타임아웃 (ms). 멈춘 fetch가 인증 플로우를 무한 대기시키지 않도록 한다 */
+const REQUEST_TIMEOUT_MS = 30_000
+
+/** 타임아웃 AbortSignal을 생성한다 */
+function timeoutSignal(): AbortSignal {
+  return AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+}
 
 /**
  * Base64URL 인코딩 (패딩 없음)
@@ -101,7 +108,7 @@ export async function createInstallationToken(
   const { jwt, installationId, hostname, fetchImpl = fetch } = params
   const url = `${apiBaseUrl(hostname)}/app/installations/${installationId}/access_tokens`
 
-  const res = await fetchImpl(url, { method: 'POST', headers: appJwtHeaders(jwt) })
+  const res = await fetchImpl(url, { method: 'POST', headers: appJwtHeaders(jwt), signal: timeoutSignal() })
   if (!res.ok) {
     const text = await res.text()
     throw new Error(`Failed to create installation token (HTTP ${res.status}): ${text.trim()}`)
@@ -131,8 +138,10 @@ async function lookupOwnerInstallation(
   headers: Record<string, string>,
   fetchImpl: typeof fetch,
 ): Promise<string> {
-  for (const path of [`/orgs/${owner}/installation`, `/users/${owner}/installation`]) {
-    const res = await fetchImpl(`${base}${path}`, { headers })
+  // owner를 URL 경로에 넣기 전 인코딩해 경로 탐색/특수문자 주입을 방지한다.
+  const encodedOwner = encodeURIComponent(owner)
+  for (const path of [`/orgs/${encodedOwner}/installation`, `/users/${encodedOwner}/installation`]) {
+    const res = await fetchImpl(`${base}${path}`, { headers, signal: timeoutSignal() })
     if (res.ok) {
       const data = await res.json() as { id: number }
       return String(data.id)
@@ -159,7 +168,9 @@ export async function resolveInstallationId(params: ResolveInstallationParams): 
     return lookupOwnerInstallation(base, owner, headers, fetchImpl)
   }
 
-  const res = await fetchImpl(`${base}/app/installations`, { headers })
+  // per_page=100으로 한 페이지에 최대치를 받아, 단일 설치 자동 선택이 페이지
+  // 잘림 때문에 잘못 동작하지 않도록 한다.
+  const res = await fetchImpl(`${base}/app/installations?per_page=100`, { headers, signal: timeoutSignal() })
   if (!res.ok) {
     const text = await res.text()
     throw new Error(`Failed to list installations (HTTP ${res.status}): ${text.trim()}`)

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -392,6 +392,44 @@ export function getPassthroughMessages(language: Language): PassthroughMessages 
   return passthroughMessages[language]
 }
 
+export interface AuthMessages {
+  resolvingInstallation: string
+  mintingToken: string
+  appLoginSuccess: (installationId: string, expiresAt: string) => string
+  tokenExpiresAt: (expiresAt: string) => string
+  gitHelperConfigured: (hostname: string) => string
+  gitHelperHint: (command: string) => string
+  errorPrefix: string
+  unknownError: string
+}
+
+const authMessages: Record<Language, AuthMessages> = {
+  ko: {
+    resolvingInstallation: '🔍 installation을 조회하는 중...',
+    mintingToken: '🔑 installation 토큰을 발급하는 중...',
+    appLoginSuccess: (id, exp) => `✅ GitHub App으로 로그인했습니다 (installation ${id}). 토큰 만료: ${exp}`,
+    tokenExpiresAt: exp => `토큰 만료: ${exp}`,
+    gitHelperConfigured: host => `✅ git credential helper를 설정했습니다 (${host}). git 작업 시 토큰이 자동 갱신됩니다.`,
+    gitHelperHint: cmd => `💡 git 토큰 자동 갱신을 활성화하려면 실행하세요:\n   ${cmd}`,
+    errorPrefix: '❌ 오류',
+    unknownError: '예상치 못한 오류가 발생했습니다',
+  },
+  en: {
+    resolvingInstallation: '🔍 Resolving installation...',
+    mintingToken: '🔑 Minting installation token...',
+    appLoginSuccess: (id, exp) => `✅ Logged in as GitHub App (installation ${id}). Token expires: ${exp}`,
+    tokenExpiresAt: exp => `Token expires: ${exp}`,
+    gitHelperConfigured: host => `✅ Configured git credential helper for ${host}. Tokens auto-refresh on git operations.`,
+    gitHelperHint: cmd => `💡 To enable git token auto-refresh, run:\n   ${cmd}`,
+    errorPrefix: '❌ Error',
+    unknownError: 'An unexpected error occurred',
+  },
+}
+
+export function getAuthMessages(language: Language): AuthMessages {
+  return authMessages[language]
+}
+
 /**
  * Detect system language from environment variables
  */

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -399,6 +399,7 @@ export interface AuthMessages {
   tokenExpiresAt: (expiresAt: string) => string
   gitHelperConfigured: (hostname: string) => string
   gitHelperHint: (command: string) => string
+  appFlagsRequireAppId: (flags: string) => string
   errorPrefix: string
   unknownError: string
 }
@@ -411,6 +412,7 @@ const authMessages: Record<Language, AuthMessages> = {
     tokenExpiresAt: exp => `토큰 만료: ${exp}`,
     gitHelperConfigured: host => `✅ git credential helper를 설정했습니다 (${host}). git 작업 시 토큰이 자동 갱신됩니다.`,
     gitHelperHint: cmd => `💡 git 토큰 자동 갱신을 활성화하려면 실행하세요:\n   ${cmd}`,
+    appFlagsRequireAppId: flags => `${flags} 옵션은 --app-id와 함께 사용해야 합니다 (GitHub App 모드 전용).`,
     errorPrefix: '❌ 오류',
     unknownError: '예상치 못한 오류가 발생했습니다',
   },
@@ -421,6 +423,7 @@ const authMessages: Record<Language, AuthMessages> = {
     tokenExpiresAt: exp => `Token expires: ${exp}`,
     gitHelperConfigured: host => `✅ Configured git credential helper for ${host}. Tokens auto-refresh on git operations.`,
     gitHelperHint: cmd => `💡 To enable git token auto-refresh, run:\n   ${cmd}`,
+    appFlagsRequireAppId: flags => `${flags} requires --app-id (GitHub App mode only).`,
     errorPrefix: '❌ Error',
     unknownError: 'An unexpected error occurred',
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,65 @@ export interface CreateIssueOptions {
 }
 
 /**
+ * GitHub App installation access token 발급 결과
+ */
+export interface InstallationTokenResult {
+  /** installation access token (약 1시간 후 만료) */
+  token: string
+  /** 만료 시각 (ISO 8601) */
+  expiresAt: string
+}
+
+/**
+ * private key 해석 옵션
+ */
+export interface ResolvePrivateKeyOptions {
+  /** 파일 경로. '-'이면 표준 입력에서 읽는다 */
+  path?: string
+  /** 폴백 환경 변수 이름 (기본: GH_APP_PRIVATE_KEY) */
+  envVarName?: string
+  /** 환경 변수 소스 (기본: process.env, 테스트 주입용) */
+  env?: Record<string, string | undefined>
+  /** 표준 입력 reader (테스트 주입용) */
+  readStdin?: () => Promise<string>
+}
+
+/**
+ * `auth login` 명령의 GitHub App 모드 옵션
+ */
+export interface AppLoginOptions {
+  /** GitHub App ID 또는 Client ID */
+  appId?: string
+  /** private key 파일 경로 ('-'이면 stdin) */
+  privateKey?: string
+  /** 대상 installation ID */
+  installationId?: string
+  /** installation 자동 조회용 org/user 이름 */
+  owner?: string
+  /** GitHub 호스트명 (GHES 지원) */
+  hostname?: string
+  /** 토큰을 저장하지 않고 표준 출력으로 인쇄 */
+  printToken?: boolean
+  /** git credential helper 자동 설정 */
+  setupGit?: boolean
+}
+
+/**
+ * GitHub App 인증 설정 (~/.please/auth.json에 영속화).
+ * 보안상 private key 값 자체는 절대 저장하지 않고 경로/환경 변수 참조만 저장한다.
+ */
+export interface AuthConfig {
+  /** GitHub App ID 또는 Client ID */
+  appId: string
+  /** 해석된 installation ID */
+  installationId: string
+  /** private key 파일 경로 (값이 아닌 참조). 환경 변수 사용 시 생략 */
+  privateKeyPath?: string
+  /** GitHub 호스트명 (github.com이 아닌 경우) */
+  hostname?: string
+}
+
+/**
  * Custom error class for JMESPath query errors
  * Provides detailed information about query failures
  */

--- a/test/commands/auth/git-credential.test.ts
+++ b/test/commands/auth/git-credential.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+import { createGitCredentialCommand, parseCredentialInput } from '../../../src/commands/auth/git-credential'
+
+describe('git-credential command', () => {
+  test('should create a command named "git-credential"', () => {
+    expect(createGitCredentialCommand().name()).toBe('git-credential')
+  })
+
+  describe('parseCredentialInput', () => {
+    test('should parse git credential key=value lines into a map', () => {
+      const input = 'protocol=https\nhost=github.com\npath=owner/repo.git\n'
+      expect(parseCredentialInput(input)).toEqual({
+        protocol: 'https',
+        host: 'github.com',
+        path: 'owner/repo.git',
+      })
+    })
+
+    test('should keep values containing "=" intact', () => {
+      expect(parseCredentialInput('url=https://x?a=b')).toEqual({ url: 'https://x?a=b' })
+    })
+
+    test('should ignore blank and malformed lines', () => {
+      expect(parseCredentialInput('\nhost=github.com\ngarbage\n\n')).toEqual({ host: 'github.com' })
+    })
+  })
+})

--- a/test/commands/auth/index.test.ts
+++ b/test/commands/auth/index.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test'
+import { createAuthCommand } from '../../../src/commands/auth'
+import { createGitCredentialCommand } from '../../../src/commands/auth/git-credential'
+import { createAuthTokenCommand } from '../../../src/commands/auth/token'
+
+describe('auth command group', () => {
+  test('should create a command named "auth"', () => {
+    expect(createAuthCommand().name()).toBe('auth')
+  })
+
+  test('should register login, token, and git-credential subcommands', () => {
+    const names = createAuthCommand().commands.map(c => c.name())
+    expect(names).toContain('login')
+    expect(names).toContain('token')
+    expect(names).toContain('git-credential')
+  })
+
+  test('should mention GitHub App support in its description', () => {
+    expect(createAuthCommand().description()).toContain('GitHub App')
+  })
+})
+
+describe('auth token command', () => {
+  test('should create a command named "token"', () => {
+    expect(createAuthTokenCommand().name()).toBe('token')
+  })
+
+  test('should describe minting from saved credentials', () => {
+    expect(createAuthTokenCommand().description()).toContain('installation token')
+  })
+})
+
+describe('auth git-credential command', () => {
+  test('should create a command named "git-credential"', () => {
+    expect(createGitCredentialCommand().name()).toBe('git-credential')
+  })
+
+  test('should require an operation argument', () => {
+    expect(createGitCredentialCommand().usage()).toContain('operation')
+  })
+})

--- a/test/commands/auth/login.test.ts
+++ b/test/commands/auth/login.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+import { buildGitHelperCommand, createAuthLoginCommand } from '../../../src/commands/auth/login'
+
+describe('auth login command', () => {
+  test('should export createAuthLoginCommand function', () => {
+    expect(typeof createAuthLoginCommand).toBe('function')
+  })
+
+  test('should create a command named "login"', () => {
+    expect(createAuthLoginCommand().name()).toBe('login')
+  })
+
+  test('should document the GitHub App and mirror behavior', () => {
+    expect(createAuthLoginCommand().description()).toContain('GitHub App')
+  })
+
+  test('should expose the App installation token options', () => {
+    const help = createAuthLoginCommand().helpInformation()
+    for (const flag of ['--app-id', '--private-key', '--installation-id', '--owner', '--hostname', '--print-token', '--setup-git']) {
+      expect(help).toContain(flag)
+    }
+  })
+
+  describe('buildGitHelperCommand', () => {
+    test('should target github.com by default', () => {
+      const cmd = buildGitHelperCommand()
+      expect(cmd).toContain('credential.https://github.com.helper')
+      expect(cmd).toContain('!gh-please auth git-credential')
+    })
+
+    test('should target a custom hostname for GHES', () => {
+      expect(buildGitHelperCommand('github.example.com')).toContain('credential.https://github.example.com.helper')
+    })
+  })
+})

--- a/test/lib/auth-config.test.ts
+++ b/test/lib/auth-config.test.ts
@@ -1,0 +1,86 @@
+import type { AuthConfig } from '../../src/types'
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { getAuthConfigPath, readAuthConfig, writeAuthConfig } from '../../src/lib/auth-config'
+
+const tmpDirs: string[] = []
+
+function makeTmpPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-please-auth-'))
+  tmpDirs.push(dir)
+  return join(dir, 'nested', 'auth.json')
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('auth-config', () => {
+  describe('getAuthConfigPath', () => {
+    test('should point at ~/.please/auth.json', () => {
+      expect(getAuthConfigPath()).toContain('.please')
+      expect(getAuthConfigPath().endsWith('auth.json')).toBe(true)
+    })
+  })
+
+  describe('writeAuthConfig / readAuthConfig', () => {
+    test('should round-trip a config, creating parent directories', () => {
+      const path = makeTmpPath()
+      const config: AuthConfig = {
+        appId: '123',
+        installationId: '456',
+        privateKeyPath: '/keys/app.pem',
+        hostname: 'github.example.com',
+      }
+
+      writeAuthConfig(config, path)
+
+      expect(existsSync(path)).toBe(true)
+      expect(readAuthConfig(path)).toEqual(config)
+    })
+
+    test('should write the file with owner-only (0600) permissions', () => {
+      const path = makeTmpPath()
+      writeAuthConfig({ appId: '1', installationId: '2' }, path)
+
+      const mode = statSync(path).mode & 0o777
+      expect(mode).toBe(0o600)
+    })
+
+    test('should never persist a private key value', () => {
+      const path = makeTmpPath()
+      writeAuthConfig({ appId: '1', installationId: '2', privateKeyPath: '/keys/app.pem' }, path)
+
+      const raw = Bun.file(path)
+      // privateKeyPath(경로 참조)만 저장되고 PEM 본문 키가 없어야 한다
+      const stored = readAuthConfig(path)!
+      expect(stored.privateKeyPath).toBe('/keys/app.pem')
+      expect(Object.keys(stored)).not.toContain('privateKey')
+      void raw
+    })
+  })
+
+  describe('readAuthConfig edge cases', () => {
+    test('should return null when the file does not exist', () => {
+      expect(readAuthConfig(makeTmpPath())).toBeNull()
+    })
+
+    test('should return null for malformed JSON', () => {
+      const path = makeTmpPath()
+      writeAuthConfig({ appId: '1', installationId: '2' }, path)
+      writeFileSync(path, '{ not json')
+      expect(readAuthConfig(path)).toBeNull()
+    })
+
+    test('should return null when required fields are missing', () => {
+      const path = makeTmpPath()
+      writeAuthConfig({ appId: '1', installationId: '2' }, path)
+      writeFileSync(path, JSON.stringify({ appId: '1' }))
+      expect(readAuthConfig(path)).toBeNull()
+    })
+  })
+})

--- a/test/lib/auth-config.test.ts
+++ b/test/lib/auth-config.test.ts
@@ -82,5 +82,19 @@ describe('auth-config', () => {
       writeFileSync(path, JSON.stringify({ appId: '1' }))
       expect(readAuthConfig(path)).toBeNull()
     })
+
+    test('should return null when required fields have wrong types', () => {
+      const path = makeTmpPath()
+      writeAuthConfig({ appId: '1', installationId: '2' }, path)
+      writeFileSync(path, JSON.stringify({ appId: 1, installationId: 2 }))
+      expect(readAuthConfig(path)).toBeNull()
+    })
+
+    test('should return null when an optional field has a wrong type', () => {
+      const path = makeTmpPath()
+      writeAuthConfig({ appId: '1', installationId: '2' }, path)
+      writeFileSync(path, JSON.stringify({ appId: '1', installationId: '2', hostname: 123 }))
+      expect(readAuthConfig(path)).toBeNull()
+    })
   })
 })

--- a/test/lib/auth-config.test.ts
+++ b/test/lib/auth-config.test.ts
@@ -90,6 +90,13 @@ describe('auth-config', () => {
       expect(readAuthConfig(path)).toBeNull()
     })
 
+    test('should return null when a required field is a blank string', () => {
+      const path = makeTmpPath()
+      writeAuthConfig({ appId: '1', installationId: '2' }, path)
+      writeFileSync(path, JSON.stringify({ appId: '', installationId: '  ' }))
+      expect(readAuthConfig(path)).toBeNull()
+    })
+
     test('should return null when an optional field has a wrong type', () => {
       const path = makeTmpPath()
       writeAuthConfig({ appId: '1', installationId: '2' }, path)

--- a/test/lib/github-app.test.ts
+++ b/test/lib/github-app.test.ts
@@ -119,6 +119,19 @@ describe('github-app', () => {
       expect(id).toBe('999')
     })
 
+    test('should URL-encode the owner to prevent path traversal/injection', async () => {
+      const requested: string[] = []
+      const fetchImpl = (async (url: string) => {
+        requested.push(url)
+        return new Response('not found', { status: 404 })
+      }) as unknown as typeof fetch
+
+      await expect(resolveInstallationId({ jwt: 'JWT', owner: '../evil', fetchImpl })).rejects.toThrow()
+      // 슬래시/점은 인코딩되어 경로에 그대로 새지 않아야 한다
+      expect(requested[0]).toContain('/orgs/..%2Fevil/installation')
+      expect(requested[0]).not.toContain('/orgs/../evil/')
+    })
+
     test('should auto-select when the app has exactly one installation', async () => {
       const fetchImpl = (async () => jsonResponse([{ id: 42, account: { login: 'solo' } }])) as unknown as typeof fetch
 

--- a/test/lib/github-app.test.ts
+++ b/test/lib/github-app.test.ts
@@ -1,0 +1,164 @@
+import { createVerify, generateKeyPairSync } from 'node:crypto'
+import { describe, expect, test } from 'bun:test'
+import {
+  apiBaseUrl,
+  createInstallationToken,
+  generateAppJwt,
+  resolveInstallationId,
+  resolvePrivateKey,
+} from '../../src/lib/github-app'
+
+const TEST_APP_ID = '123456'
+const FIXED_NOW = 1_700_000_000
+
+// 테스트용 RSA 키쌍 (각 실행마다 생성해 결정적으로 검증)
+const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+})
+
+function decodeSegment(segment: string): any {
+  return JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'))
+}
+
+/** 가짜 fetch 응답을 만든다 */
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status })
+}
+
+describe('github-app', () => {
+  describe('generateAppJwt', () => {
+    test('should produce a three-part JWT with RS256 header', () => {
+      const jwt = generateAppJwt({ appId: TEST_APP_ID, privateKey, now: FIXED_NOW })
+      const parts = jwt.split('.')
+
+      expect(parts).toHaveLength(3)
+      expect(decodeSegment(parts[0]!)).toEqual({ alg: 'RS256', typ: 'JWT' })
+    })
+
+    test('should set iat/exp/iss with clock drift and 9-minute expiry', () => {
+      const jwt = generateAppJwt({ appId: TEST_APP_ID, privateKey, now: FIXED_NOW })
+      const payload = decodeSegment(jwt.split('.')[1]!)
+
+      expect(payload.iss).toBe(TEST_APP_ID)
+      expect(payload.iat).toBe(FIXED_NOW - 60)
+      expect(payload.exp).toBe(FIXED_NOW + 540)
+    })
+
+    test('should produce a signature verifiable by the public key', () => {
+      const jwt = generateAppJwt({ appId: TEST_APP_ID, privateKey, now: FIXED_NOW })
+      const [header, payload, signature] = jwt.split('.')
+
+      const verifier = createVerify('RSA-SHA256')
+      verifier.update(`${header}.${payload}`)
+      verifier.end()
+
+      const isValid = verifier.verify(publicKey, Buffer.from(signature!, 'base64url'))
+      expect(isValid).toBe(true)
+    })
+  })
+
+  describe('apiBaseUrl', () => {
+    test('should use api.github.com for github.com or empty hostname', () => {
+      expect(apiBaseUrl()).toBe('https://api.github.com')
+      expect(apiBaseUrl('github.com')).toBe('https://api.github.com')
+    })
+
+    test('should use /api/v3 path for GitHub Enterprise Server', () => {
+      expect(apiBaseUrl('github.example.com')).toBe('https://github.example.com/api/v3')
+    })
+  })
+
+  describe('createInstallationToken', () => {
+    test('should POST to the access_tokens endpoint and return token + expiry', async () => {
+      const calls: Array<{ url: string, init?: RequestInit }> = []
+      const fetchImpl = (async (url: string, init?: RequestInit) => {
+        calls.push({ url, init })
+        return jsonResponse({ token: 'ghs_abc123', expires_at: '2026-06-25T13:00:00Z' })
+      }) as unknown as typeof fetch
+
+      const result = await createInstallationToken({ jwt: 'JWT', installationId: '789', fetchImpl })
+
+      expect(result).toEqual({ token: 'ghs_abc123', expiresAt: '2026-06-25T13:00:00Z' })
+      expect(calls[0]!.url).toBe('https://api.github.com/app/installations/789/access_tokens')
+      expect(calls[0]!.init?.method).toBe('POST')
+    })
+
+    test('should throw with status when the API returns an error', async () => {
+      const fetchImpl = (async () => new Response('bad creds', { status: 401 })) as unknown as typeof fetch
+
+      await expect(
+        createInstallationToken({ jwt: 'JWT', installationId: '789', fetchImpl }),
+      ).rejects.toThrow('HTTP 401')
+    })
+  })
+
+  describe('resolveInstallationId', () => {
+    test('should resolve org installation when owner is provided', async () => {
+      const fetchImpl = (async (url: string) => {
+        if (url.endsWith('/orgs/pleaseai/installation')) {
+          return jsonResponse({ id: 456 })
+        }
+        return new Response('not found', { status: 404 })
+      }) as unknown as typeof fetch
+
+      const id = await resolveInstallationId({ jwt: 'JWT', owner: 'pleaseai', fetchImpl })
+      expect(id).toBe('456')
+    })
+
+    test('should fall back to user installation when org is 404', async () => {
+      const fetchImpl = (async (url: string) => {
+        if (url.endsWith('/users/amondnet/installation')) {
+          return jsonResponse({ id: 999 })
+        }
+        return new Response('not found', { status: 404 })
+      }) as unknown as typeof fetch
+
+      const id = await resolveInstallationId({ jwt: 'JWT', owner: 'amondnet', fetchImpl })
+      expect(id).toBe('999')
+    })
+
+    test('should auto-select when the app has exactly one installation', async () => {
+      const fetchImpl = (async () => jsonResponse([{ id: 42, account: { login: 'solo' } }])) as unknown as typeof fetch
+
+      const id = await resolveInstallationId({ jwt: 'JWT', fetchImpl })
+      expect(id).toBe('42')
+    })
+
+    test('should throw listing options when multiple installations exist', async () => {
+      const fetchImpl = (async () => jsonResponse([
+        { id: 1, account: { login: 'a' } },
+        { id: 2, account: { login: 'b' } },
+      ])) as unknown as typeof fetch
+
+      await expect(resolveInstallationId({ jwt: 'JWT', fetchImpl })).rejects.toThrow('Multiple installations found')
+    })
+
+    test('should throw when no installations exist', async () => {
+      const fetchImpl = (async () => jsonResponse([])) as unknown as typeof fetch
+
+      await expect(resolveInstallationId({ jwt: 'JWT', fetchImpl })).rejects.toThrow('No installations found')
+    })
+  })
+
+  describe('resolvePrivateKey', () => {
+    test('should read from the environment variable fallback', async () => {
+      const key = await resolvePrivateKey({ env: { GH_APP_PRIVATE_KEY: 'PEM-FROM-ENV' } })
+      expect(key).toBe('PEM-FROM-ENV')
+    })
+
+    test('should read from stdin when path is "-"', async () => {
+      const key = await resolvePrivateKey({ path: '-', readStdin: async () => '  PEM-FROM-STDIN  ' })
+      expect(key).toBe('PEM-FROM-STDIN')
+    })
+
+    test('should throw when stdin is empty', async () => {
+      await expect(resolvePrivateKey({ path: '-', readStdin: async () => '   ' })).rejects.toThrow('stdin')
+    })
+
+    test('should throw a helpful error when no source is available', async () => {
+      await expect(resolvePrivateKey({ env: {} })).rejects.toThrow('Private key required')
+    })
+  })
+})


### PR DESCRIPTION
## 개요

`gh please auth`를 추가해 `gh auth`를 미러링하면서 **GitHub App installation token** 발급·재발급을 지원합니다. 네이티브 `gh auth login`은 사용자(OAuth/PAT) 인증만 지원하고 App installation 인증 경로가 없어, CI·봇·서버 간 자동화에 필요한 짧은 수명(~1시간)의 스코프 토큰을 CLI에서 다룰 수 없었습니다.

설계 근거는 `docs-dev/adr/0008-auth-github-app-installation-tokens.md`, 사용법은 `docs-dev/AUTH_WORKFLOW.md`를 참고하세요.

## 명령 구성

| 명령 | 동작 |
|------|------|
| `gh please auth login` (App 플래그 없음) | `gh auth login` 그대로 미러링 (stdio 상속 → 대화형 플로우 유지) |
| `gh please auth login --app-id … --private-key …` | installation token 발급, `--with-token`으로 저장(또는 `--print-token`), 재발급용 설정 저장 |
| `gh please auth token` | 저장된 App 설정으로 새 토큰 재발급(없으면 `gh auth token` 미러링) |
| `gh please auth git-credential <op>` | git 작업마다 새 토큰을 발급하는 credential helper (투명 자동 갱신) |
| `gh please auth <status\|logout\|…>` | gh CLI 패스스루 |

## 주요 설계 결정

- **미러링은 재파싱이 아닌 원본 인자 포워딩** — `--app-id`가 없으면 `process.argv` 꼬리를 그대로 `gh auth login`에 넘기고 stdio를 상속해 네이티브 동작·TTY 프롬프트를 100% 보존.
- **무의존성 JWT 서명** — RS256 JWT를 Bun 내장 `node:crypto`로 서명(신규 의존성 없음).
- **토큰 전달: 기본 저장, 필요 시 인쇄** — 기본은 `gh auth login --with-token`, `--print-token`은 CI용(`export GH_TOKEN=$(… --print-token)`).
- **자동 갱신 = 재발급** — installation token은 OAuth 갱신이 불가하므로 App 설정을 `~/.please/auth.json`에 저장하고 온디맨드로 재발급. git credential helper로 git 작업 시 데몬 없이 투명 갱신.
- **비밀 값 미저장** — `auth.json`에는 private key 경로 참조만 저장(PEM 본문 미저장), 파일 권한 `0600`. stdin 키는 일회성(재발급 불가).
- **installation 해석 계층** — `--installation-id` → `--owner`(org→user 조회) → 단일 설치 자동 선택.
- **GHES 지원** — `--hostname` → `/api/v3`.

### private key 소스 (우선순위)
1. `--private-key -` (stdin)
2. `--private-key <path>` (파일)
3. `GH_APP_PRIVATE_KEY` 환경 변수 (PEM 본문)

## 변경 파일

- `src/lib/github-app.ts` — JWT 서명, installation 해석, 토큰 발급, key 해석
- `src/lib/auth-config.ts` — `~/.please/auth.json` 읽기/쓰기(0600, 비밀 값 미저장)
- `src/lib/app-auth.ts` — 저장된 설정 기반 재발급 오케스트레이션
- `src/commands/auth/{index,login,token,git-credential}.ts` — 명령 구성
- `src/{index,types}.ts`, `src/lib/i18n.ts` — 명령 등록 / 타입 / 메시지(ko·en)
- docs: ADR 0008, AUTH_WORKFLOW.md, CLAUDE.md

## 테스트

- `bun run lint:fix`, `bun run type-check` 통과
- 신규 테스트 36개 통과:
  - `test/lib/github-app.test.ts` — 실제 RSA 키쌍으로 JWT 서명 검증, installation 해석(org/user/auto/다중/없음), 토큰 발급, key 해석
  - `test/lib/auth-config.test.ts` — 0600 권한, 비밀 값 미저장 라운드트립, 손상/누락 처리
  - `test/commands/auth/*` — 명령 등록/플래그/설명
- auth + passthrough + index 스위트 56개 동시 통과 (회귀 없음)

> 참고: 풀 스위트의 `Format Flag Integration Tests` 10개 실패는 **기존 결함**입니다(이 브랜치 변경을 모두 stash해도 실패, 단독 실행 시 통과 — 테스트 순서 의존성 이슈로 본 PR과 무관).

## 남은 작업

- 실제 종단 검증에는 GitHub App(App ID + private key)이 필요합니다. crypto/HTTP 계층은 fetch 주입으로 단위 테스트됨.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `gh please auth` that mirrors `gh auth` and adds GitHub App installation token login, re-mint, and a git credential helper with host-scoped auto-refresh. Improves security and reliability (timeouts, strict config perms, safer installation resolution) and supports GHES.

- **New Features**
  - `gh please auth login`: with `--app-id` and `--private-key` mints an installation token; `--print-token` for CI; otherwise stores via `gh auth login --with-token`. Optional `--setup-git` configures the helper.
  - Installation resolution: `--installation-id` → `--owner` (org→user lookup) → auto-select when only one exists. Private key sources: `--private-key <path>`, `--private-key -` (stdin), or `GH_APP_PRIVATE_KEY`. Config saved to `~/.please/auth.json` (0600), uses absolute paths, and never persists the PEM; stdin keys are one-shot and not saved.
  - `gh please auth token` re-mints a fresh token from saved config; `gh please auth git-credential` mints a new token per git op and only for HTTPS requests to the configured host.
  - GHES via `--hostname` (`/api/v3`); JWT signed with `node:crypto`; all API calls have a 30s timeout.

- **Bug Fixes**
  - Clear error when App-only flags are used without `--app-id`.
  - Owner names are URL-encoded; installation listing uses `per_page=100`.
  - Config hardening: field type checks, blank required fields are rejected, and `~/.please` dir/file permissions are enforced (`0700`/`0600`) on every write.

<sup>Written for commit 839b9e04cefe361a103413bd316b0c502635064c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `auth` command group with `login`, `token`, and `git-credential` helper support.
  * Supports GitHub App authentication for minting installation tokens, on-demand re-minting, and automatic token refresh via git credential helper (including GitHub Enterprise).
* **Documentation**
  * Added/updated an authentication workflow guide and a related design note, including one-time login behavior and security guidance for private keys/tokens.
* **Tests**
  * Introduced Bun test coverage for the new auth commands, token/JWT generation, and config persistence/permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->