### PR TITLE
chore: normalize LICENSE copyright to Passion Factory and add community-health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report a problem to help us improve
+title: ""
+labels: ["bug"]
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To reproduce
+
+Steps to reproduce the behavior:
+
+1. ...
+2. ...
+3. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Environment
+
+- Package version:
+- Runtime/OS:
+
+## Additional context
+
+Logs, screenshots, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/pleaseai/gh-please/discussions
+    about: Ask questions and discuss ideas here instead of opening an issue.
+  - name: Security vulnerability
+    url: https://github.com/pleaseai/gh-please/security/advisories/new
+    about: Report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: ""
+labels: ["enhancement"]
+---
+
+## Problem
+
+What problem does this feature solve? What is the use case?
+
+## Proposed solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives considered
+
+Other approaches you've thought about, and why this one is preferable.
+
+## Additional context
+
+Anything else that helps explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits
+- [ ] Tests added or updated, and the suite passes (`bun run test`)
+- [ ] Lint/format pass (`bun run lint`)
+- [ ] Documentation updated if behavior changed
+- [ ] No breaking change, or a `BREAKING CHANGE:` note is included

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,7 @@
 - [ ] PR title follows Conventional Commits
 - [ ] Tests added or updated, and the suite passes (`bun run test`)
 - [ ] Lint/format pass (`bun run lint`)
+- [ ] Type-check passes (`bun run type-check`)
+- [ ] Build passes (`bun run build`)
 - [ ] Documentation updated if behavior changed
 - [ ] No breaking change, or a `BREAKING CHANGE:` note is included

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@pleaseai.dev**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+Thanks for your interest in contributing! This guide covers how to get from a clone to a merged pull request.
+
+By participating, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md). All documentation, code, comments, and commit messages in this repository are written in **English**.
+
+## Getting started
+
+This project uses [Bun](https://bun.sh) as its runtime and package manager.
+
+```bash
+git clone https://github.com/pleaseai/gh-please.git
+cd gh-please
+bun install         # install dependencies
+```
+
+## Development workflow
+
+1. Create a branch from `main` (e.g. `feat/short-description` or `fix/issue-123`).
+2. Make focused changes — keep each pull request to one logical change.
+3. Run the checks below and make sure they pass.
+4. Open a pull request and fill out the template.
+
+```bash
+bun run lint        # lint and format
+bun run type-check  # type-check with tsc
+bun run test        # run the test suite
+bun run build       # ensure it builds
+```
+
+## Commit messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): subject`, where `type` is one of `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, etc. Breaking changes include a `BREAKING CHANGE:` footer. Versioning and the changelog are generated automatically from these messages, so accurate types matter.
+
+## Pull requests
+
+- Reference the issue your PR addresses (e.g. `Closes #123`).
+- Use a Conventional-Commit-style PR title — it becomes the squash-merge commit.
+- Make sure CI is green before requesting review.
+
+## Reporting bugs and requesting features
+
+Open an issue using the bug report or feature request template. For security
+vulnerabilities, **do not** open a public issue — follow [SECURITY.md](./SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing! This guide covers how to get from a clone to a merged pull request.
 
-By participating, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md). All documentation, code, comments, and commit messages in this repository are written in **English**.
+By participating, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md). While documentation is provided in both English and Korean, all code, comments, and commit messages in this repository are written in **English**.
 
 ## Getting started
 
@@ -22,7 +22,7 @@ bun install         # install dependencies
 4. Open a pull request and fill out the template.
 
 ```bash
-bun run lint        # lint and format
+bun run lint:fix    # lint and auto-fix
 bun run type-check  # type-check with tsc
 bun run test        # run the test suite
 bun run build       # ensure it builds

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 PleaseAI
+Copyright (c) 2025 Passion Factory
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CI](https://github.com/pleaseai/gh-please/actions/workflows/ci.yml/badge.svg)](https://github.com/pleaseai/gh-please/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/pleaseai/gh-please/graph/badge.svg?token=BQKO959X1M)](https://codecov.io/github/pleaseai/gh-please)
 [![code style](https://antfu.me/badge-code-style.svg)](https://github.com/antfu/eslint-config)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
 GitHub CLI extension - GitHub tools for LLMs
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest released major version. Older
+versions may receive fixes at the maintainers' discretion.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | :white_check_mark: |
+| older   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report them privately through GitHub's
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability):
+go to the repository's **Security** tab and click **"Report a vulnerability"**.
+
+If you cannot use that channel, email **security@pleaseai.dev** instead.
+
+Please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce, or a proof of concept
+- Affected versions, and any known mitigations
+
+## What to Expect
+
+- We aim to acknowledge your report within **72 hours**.
+- We will keep you informed of progress toward a fix and may ask for additional
+  detail.
+- Once a fix is released, we will credit you in the advisory unless you prefer
+  to remain anonymous.
+
+We ask that you give us a reasonable opportunity to address the issue before any
+public disclosure.


### PR DESCRIPTION
## Summary

Normalizes the LICENSE copyright holder and adds the standard open-source community-health files.

- `LICENSE`: copyright holder `PleaseAI` -> `Passion Factory` (year 2025 unchanged)
- `CONTRIBUTING.md`: bun-based setup and workflow (clone, `bun install`, `bun run lint/type-check/test/build`)
- `CODE_OF_CONDUCT.md`: Contributor Covenant v2.1, contact `conduct@pleaseai.dev`
- `SECURITY.md`: private vulnerability reporting, contact `security@pleaseai.dev`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/ISSUE_TEMPLATE/`: `bug_report.md`, `feature_request.md`, `config.yml`
- `README.md`: added a `License: MIT` badge to the badge row (an npm version badge was already present, so no npm badge was added to avoid a duplicate)

## Related issue

<!-- none -->

## Checklist

- [x] PR title follows Conventional Commits
- [x] Docs-only change (no code, tests unaffected)
- [x] No breaking change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize LICENSE holder to Passion Factory and add community health files to guide contributions, conduct, and security. Includes Contributor Covenant v2.1 (conduct@pleaseai.dev), SECURITY policy with private reporting via GitHub advisories or security@pleaseai.dev, CONTRIBUTING with Bun workflow, PR/issue templates that link to Discussions and disable blank issues, and an MIT license badge in the README.

<sup>Written for commit d217beb3081059b65107426815b99c3663758d4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

